### PR TITLE
Include tcp/udp in docker compose config to allow udp dns queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
   powerdns:
     image: psitrax/powerdns
     ports:
-      - "53:53"
+      - "53:53/tcp"
+      - "53:53/udp"
       - "8081:8081"
     environment:
       MYSQL_HOST: db


### PR DESCRIPTION
Only opened up TCP previously. 