### PR TITLE
Convert _PowerDnsLuaValue to dict-based

### DIFF
--- a/octodns_powerdns/record.py
+++ b/octodns_powerdns/record.py
@@ -2,7 +2,7 @@ from octodns.record import Record, ValuesMixin
 from octodns.equality import EqualityTupleMixin
 
 
-class _PowerDnsLuaValue(EqualityTupleMixin):
+class _PowerDnsLuaValue(EqualityTupleMixin, dict):
     # See https://doc.powerdns.com/authoritative/lua-records/index.html for the
     # LUA record docs and
     # https://gist.github.com/ahupowerdns/1e8bfbba95a277a4fac09cb3654eb2ac
@@ -31,8 +31,24 @@ class _PowerDnsLuaValue(EqualityTupleMixin):
         self.script = value['script']
 
     @property
+    def _type(self):
+        return self['type']
+
+    @_type.setter
+    def _type(self, value):
+        self['type'] = value
+
+    @property
+    def script(self):
+        return self['script']
+
+    @script.setter
+    def script(self, value):
+        self['script'] = value
+
+    @property
     def data(self):
-        return {'script': self.script, 'type': self._type}
+        return self
 
     def __hash__(self):
         return hash((self._type,))

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -26,7 +26,7 @@ from octodns_powerdns import (
     PowerDnsProvider,
     _escape_unescaped_semicolons,
 )
-from octodns_powerdns.record import PowerDnsLuaRecord
+from octodns_powerdns.record import _PowerDnsLuaValue, PowerDnsLuaRecord
 
 EMPTY_TEXT = '''
 {
@@ -504,7 +504,11 @@ class TestPowerDnsLuaRecord(TestCase):
             },
         )
         self.assertEqual(
-            {'ttl': 42, 'value': {'script': '1.2.3.4', 'type': 'A'}}, lua.data
+            {
+                'ttl': 42,
+                'value': _PowerDnsLuaValue({'script': '1.2.3.4', 'type': 'A'}),
+            },
+            lua.data,
         )
 
         # valid record with a multiple values
@@ -515,8 +519,8 @@ class TestPowerDnsLuaRecord(TestCase):
                 'type': PowerDnsLuaRecord._type,
                 'ttl': 42,
                 'values': [
-                    {'script': '1.2.3.4', 'type': 'A'},
-                    {'script': 'fc00::42', 'type': 'AAAA'},
+                    _PowerDnsLuaValue({'script': '1.2.3.4', 'type': 'A'}),
+                    _PowerDnsLuaValue({'script': 'fc00::42', 'type': 'AAAA'}),
                 ],
             },
         )
@@ -524,8 +528,8 @@ class TestPowerDnsLuaRecord(TestCase):
             {
                 'ttl': 42,
                 'values': [
-                    {'script': '1.2.3.4', 'type': 'A'},
-                    {'script': 'fc00::42', 'type': 'AAAA'},
+                    _PowerDnsLuaValue({'script': '1.2.3.4', 'type': 'A'}),
+                    _PowerDnsLuaValue({'script': 'fc00::42', 'type': 'AAAA'}),
                 ],
             },
             luas.data,


### PR DESCRIPTION
Update `_PowerDnsLuaValue` to match changes made to core objects in https://github.com/octodns/octodns/pull/929.