### PR TITLE
add mode_of_operation managed attribute. modify soa_edit_api 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 .coverage
 .eggs/
 .env
-.vscode/
-.python-version
 /build/
 /config/
 coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .coverage
 .eggs/
 .env
+.vscode/
+.python-version
 /build/
 /config/
 coverage.xml

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -35,7 +35,7 @@ EMPTY_TEXT = '''
     "rrsets": [],
     "serial": 2017012801,
     "soa_edit": "",
-    "soa_edit_api": "INCEPTION-INCREMENT",
+    "soa_edit_api": "default",
     "url": "api/v1/servers/localhost/zones/xunit.tests."
 }
 '''
@@ -71,12 +71,7 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.1.10"},
             )
-            provider = PowerDnsProvider(
-                'test',
-                'non.existent',
-                'api-key',
-                soa_edit_api='INCEPTION-INCREMENT',
-            )
+            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 
         # Test version detection for second time (should stay at 4.1.10)
@@ -128,13 +123,8 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.1.10"},
             )
-            provider = PowerDnsProvider(
-                'test',
-                'non.existent',
-                'api-key',
-                soa_edit_api='INCEPTION-INCREMENT',
-            )
-            self.assertEqual(provider.soa_edit_api, 'INCEPTION-INCREMENT')
+            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+            self.assertEqual(provider.soa_edit_api, 'default')
             self.assertEqual(provider.mode_of_operation, 'master')
             self.assertFalse(
                 provider.check_status_not_found,
@@ -150,7 +140,7 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.2.0"},
             )
-            self.assertEqual(provider.soa_edit_api, 'INCEPTION-INCREMENT')
+            self.assertEqual(provider.soa_edit_api, 'default')
             self.assertEqual(provider.mode_of_operation, 'master')
             self.assertTrue(
                 provider.check_status_not_found,
@@ -169,11 +159,11 @@ class TestPowerDnsProvider(TestCase):
                 'test',
                 'non.existent',
                 'api-key',
-                soa_edit_api="SOA-EDIT",
-                mode_of_operation="master",
+                soa_edit_api="soa-edit",
+                mode_of_operation="slave",
             )
-            self.assertEqual(provider.soa_edit_api, 'SOA-EDIT')
-            self.assertEqual(provider.mode_of_operation, 'master')
+            self.assertEqual(provider.soa_edit_api, 'soa-edit')
+            self.assertEqual(provider.mode_of_operation, 'slave')
             self.assertTrue(
                 provider.check_status_not_found,
                 'check_status_not_found should be true for version 4.3.x',
@@ -191,10 +181,10 @@ class TestPowerDnsProvider(TestCase):
                 'test',
                 'non.existent',
                 'api-key',
-                soa_edit_api="EPOCH",
+                soa_edit_api="epoch",
                 mode_of_operation="primary",
             )
-            self.assertEqual(provider.soa_edit_api, 'EPOCH')
+            self.assertEqual(provider.soa_edit_api, 'epoch')
             self.assertEqual(provider.mode_of_operation, 'primary')
             self.assertTrue(
                 provider.check_status_not_found,
@@ -211,18 +201,21 @@ class TestPowerDnsProvider(TestCase):
 
             with self.assertRaises(ValueError) as ctx:
                 PowerDnsProvider(
-                    'test', 'non.existent', 'api-key', soa_edit_api='EPOCH'
+                    'test',
+                    'non.existent',
+                    'api-key',
+                    soa_edit_api='inception-increment',
                 )
             self.assertTrue(
                 '"soa_edit_api" - possibile values:' in str(ctx.exception)
             )
 
+            # "Primary" is available since pdns v4.5
             with self.assertRaises(ValueError) as ctx:
                 PowerDnsProvider(
                     'test',
                     'non.existent',
                     'api-key',
-                    soa_edit_api='INCEPTION-INCREMENT',
                     mode_of_operation='primary',
                 )
             self.assertTrue(
@@ -238,12 +231,7 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.1.10"},
             )
-            provider = PowerDnsProvider(
-                'test',
-                'non.existent',
-                'api-key',
-                soa_edit_api='INCEPTION-INCREMENT',
-            )
+            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 
         # Bad auth
@@ -409,12 +397,7 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': '4.1.0'},
             )
-            provider = PowerDnsProvider(
-                'test',
-                'non.existent',
-                'api-key',
-                soa_edit_api='INCEPTION-INCREMENT',
-            )
+            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
 
             missing = Zone(expected.name, [])
             # Find and delete the SPF record
@@ -464,7 +447,6 @@ class TestPowerDnsProvider(TestCase):
                     'api-key',
                     nameserver_values=['8.8.8.8.', '9.9.9.9.'],
                     nameserver_ttl=600,
-                    soa_edit_api='INCEPTION-INCREMENT',
                 )
             self.assertTrue(
                 str(ctx.exception).startswith(
@@ -485,12 +467,7 @@ class TestPowerDnsProvider(TestCase):
                     status_code=200,
                     json={'version': "4.1.10"},
                 )
-                ChildProvider(
-                    'text',
-                    'non.existent',
-                    'api-key',
-                    soa_edit_api='INCEPTION-INCREMENT',
-                )
+                ChildProvider('text', 'non.existent', 'api-key')
             self.assertTrue(
                 str(ctx.exception).startswith(
                     '_get_nameserver_record no longer supported;'

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -29,6 +29,7 @@ EMPTY_TEXT = '''
     "kind": "Master",
     "last_check": 0,
     "masters": [],
+    "mode_of_operation": "master",
     "name": "xunit.tests.",
     "notified_serial": 0,
     "rrsets": [],
@@ -45,12 +46,12 @@ with open('./tests/fixtures/powerdns-full-data.json') as fh:
 
 class TestPowerDnsProvider(TestCase):
     def test_provider_version_detection(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
         # Bad auth
         with requests_mock() as mock:
             mock.get(ANY, status_code=401, text='Unauthorized')
 
             with self.assertRaises(Exception) as ctx:
+                provider = PowerDnsProvider('test', 'non.existent', 'api-key')
                 provider.powerdns_version
             self.assertTrue('unauthorized' in str(ctx.exception))
 
@@ -59,6 +60,7 @@ class TestPowerDnsProvider(TestCase):
             mock.get(ANY, status_code=404, text='Not Found')
 
             with self.assertRaises(Exception) as ctx:
+                provider = PowerDnsProvider('test', 'non.existent', 'api-key')
                 provider.powerdns_version
             self.assertTrue('404' in str(ctx.exception))
 
@@ -68,6 +70,12 @@ class TestPowerDnsProvider(TestCase):
                 'http://non.existent:8081/api/v1/servers/localhost',
                 status_code=200,
                 json={'version': "4.1.10"},
+            )
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api='INCEPTION-INCREMENT',
             )
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 
@@ -112,17 +120,22 @@ class TestPowerDnsProvider(TestCase):
             self.assertEqual(provider.powerdns_version, [4, 5, 0])
 
     def test_provider_version_config(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
 
         # Test version 4.1.0
-        provider._powerdns_version = None
         with requests_mock() as mock:
             mock.get(
                 'http://non.existent:8081/api/v1/servers/localhost',
                 status_code=200,
                 json={'version': "4.1.10"},
             )
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api='INCEPTION-INCREMENT',
+            )
             self.assertEqual(provider.soa_edit_api, 'INCEPTION-INCREMENT')
+            self.assertEqual(provider.mode_of_operation, 'master')
             self.assertFalse(
                 provider.check_status_not_found,
                 'check_status_not_found should be false '
@@ -138,6 +151,7 @@ class TestPowerDnsProvider(TestCase):
                 json={'version': "4.2.0"},
             )
             self.assertEqual(provider.soa_edit_api, 'INCEPTION-INCREMENT')
+            self.assertEqual(provider.mode_of_operation, 'master')
             self.assertTrue(
                 provider.check_status_not_found,
                 'check_status_not_found should be true for version 4.2.x',
@@ -151,14 +165,71 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.3.0"},
             )
-            self.assertEqual(provider.soa_edit_api, 'DEFAULT')
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api="SOA-EDIT",
+                mode_of_operation="master",
+            )
+            self.assertEqual(provider.soa_edit_api, 'SOA-EDIT')
+            self.assertEqual(provider.mode_of_operation, 'master')
             self.assertTrue(
                 provider.check_status_not_found,
                 'check_status_not_found should be true for version 4.3.x',
             )
 
+        # Test version 4.5.0
+        # mode_of_operation primary preffered over master and secondary prefered over slave.
+        with requests_mock() as mock:
+            mock.get(
+                'http://non.existent:8081/api/v1/servers/localhost',
+                status_code=200,
+                json={'version': "4.5.0"},
+            )
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api="EPOCH",
+                mode_of_operation="primary",
+            )
+            self.assertEqual(provider.soa_edit_api, 'EPOCH')
+            self.assertEqual(provider.mode_of_operation, 'primary')
+            self.assertTrue(
+                provider.check_status_not_found,
+                'check_status_not_found should be true for version 4.5.x',
+            )
+
+    def test_managed_attribute_validation(self):
+        with requests_mock() as mock:
+            mock.get(
+                'http://non.existent:8081/api/v1/servers/localhost',
+                status_code=200,
+                json={'version': "4.2.0"},
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                PowerDnsProvider(
+                    'test', 'non.existent', 'api-key', soa_edit_api='EPOCH'
+                )
+            self.assertTrue(
+                '"soa_edit_api" - possibile values:' in str(ctx.exception)
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                PowerDnsProvider(
+                    'test',
+                    'non.existent',
+                    'api-key',
+                    soa_edit_api='INCEPTION-INCREMENT',
+                    mode_of_operation='primary',
+                )
+            self.assertTrue(
+                '"mode_of_operation" - possible values:' in str(ctx.exception)
+            )
+
     def test_provider(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
 
         # Test version detection
         with requests_mock() as mock:
@@ -166,6 +237,12 @@ class TestPowerDnsProvider(TestCase):
                 'http://non.existent:8081/api/v1/servers/localhost',
                 status_code=200,
                 json={'version': "4.1.10"},
+            )
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api='INCEPTION-INCREMENT',
             )
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 
@@ -317,8 +394,6 @@ class TestPowerDnsProvider(TestCase):
                 provider.apply(plan)
 
     def test_small_change(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
-
         expected = Zone('unit.tests.', [])
         source = YamlProvider(
             'test', join(dirname(__file__), 'config'), supports_root_ns=False
@@ -333,6 +408,12 @@ class TestPowerDnsProvider(TestCase):
                 'http://non.existent:8081/api/v1/servers/localhost',
                 status_code=200,
                 json={'version': '4.1.0'},
+            )
+            provider = PowerDnsProvider(
+                'test',
+                'non.existent',
+                'api-key',
+                soa_edit_api='INCEPTION-INCREMENT',
             )
 
             missing = Zone(expected.name, [])
@@ -370,20 +451,26 @@ class TestPowerDnsProvider(TestCase):
             self.assertEqual(1, provider.apply(plan))
 
     def test_nameservers_params(self):
-
-        with self.assertRaises(ProviderException) as ctx:
-            PowerDnsProvider(
-                'test',
-                'non.existent',
-                'api-key',
-                nameserver_values=['8.8.8.8.', '9.9.9.9.'],
-                nameserver_ttl=600,
+        with requests_mock() as mock:
+            mock.get(
+                'http://non.existent:8081/api/v1/servers/localhost',
+                status_code=200,
+                json={'version': "4.1.10"},
             )
-        self.assertTrue(
-            str(ctx.exception).startswith(
-                'nameserver_values parameter no longer supported'
+            with self.assertRaises(ProviderException) as ctx:
+                PowerDnsProvider(
+                    'test',
+                    'non.existent',
+                    'api-key',
+                    nameserver_values=['8.8.8.8.', '9.9.9.9.'],
+                    nameserver_ttl=600,
+                    soa_edit_api='INCEPTION-INCREMENT',
+                )
+            self.assertTrue(
+                str(ctx.exception).startswith(
+                    'nameserver_values parameter no longer supported'
+                )
             )
-        )
 
         class ChildProvider(PowerDnsBaseProvider):
             log = getLogger('ChildProvider')
@@ -392,12 +479,23 @@ class TestPowerDnsProvider(TestCase):
                 pass
 
         with self.assertRaises(ProviderException) as ctx:
-            ChildProvider('text', 'non.existent', 'api-key')
-        self.assertTrue(
-            str(ctx.exception).startswith(
-                '_get_nameserver_record no longer supported;'
+            with requests_mock() as mock:
+                mock.get(
+                    'http://non.existent:8081/api/v1/servers/localhost',
+                    status_code=200,
+                    json={'version': "4.1.10"},
+                )
+                ChildProvider(
+                    'text',
+                    'non.existent',
+                    'api-key',
+                    soa_edit_api='INCEPTION-INCREMENT',
+                )
+            self.assertTrue(
+                str(ctx.exception).startswith(
+                    '_get_nameserver_record no longer supported;'
+                )
             )
-        )
 
     def test_unescaped_semicolon(self):
         # no escapes


### PR DESCRIPTION
This proposal adds validation of the configured attribute which relies on the powerdns_version method.
I have not yet touched the soa_edit_api which is set to INCEPTION-INCREMENT pdns versions below 4.3, but it is incorrect for this type of setting. It would be is valid for soa_edit instead as described in:
https://doc.powerdns.com/authoritative/dnssec/operational.html#soa-edit-ensure-signature-freshness-on-slaves
I have browsed through older pdns documentation from 4.0 to 4.5 and did not find this has changed.

soa_edit_api selection is described in https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api and matches settings of [SOA-EDIT-DNSUPDATE](https://doc.powerdns.com/authoritative/dnsupdate.html#dnsupdate-soa-serial-updates).

It seams that there was an issue in pdns which is also mentioned in https://github.com/tuxis-ie/nsedit/pull/189 
I think that it introduced an error while validating this setting setting at some point in a 4.3 version. I can not reproduce it though as every value is being accepted by the API, which in case of an incorrect one must defaults to DEFAULT. The following tested with v4.[2,3,6,8alpha]
 
```
octodns-powerdns-powerdns-1  | Oct 27 12:42:25 SOA-EDIT-API/DNSUPDATE type 'INCEPTION-INCREMENT' for zone test.example.org is unknown.
```