### PR TITLE
Release 0.0.2 version bump and CHANGELOG updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2022-??-?? - Root NS Records and (beta) LUA record support
+## v0.0.2 - 2022-11-09 - Root NS Records and (beta) LUA record support
 
 #### Nothworthy Changes
 
@@ -14,3 +14,4 @@
   https://doc.powerdns.com/authoritative/lua-records/index.html for their doc
   and https://gist.github.com/ahupowerdns/1e8bfbba95a277a4fac09cb3654eb2ac for
   some of what's possible.
+* Allow configuring mode_of_operation and soa_edit_api via provider parameters

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -12,7 +12,7 @@ from octodns.provider.base import BaseProvider
 
 from .record import PowerDnsLuaRecord
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 def _escape_unescaped_semicolons(value):


### PR DESCRIPTION
## v0.0.2 - 2022-11-09 - Root NS Records and (beta) LUA record support

#### Nothworthy Changes

* Root NS record management support added, requires octodns>=0.9.16,
  `nameserver_values` and `nameserver_ttl` support removed. managing PowerDNS
  root NS records should migrate to sources (usually YamlProvider, but could
  utilize dynamic source/provider if necessary)
* Support for `_get_nameserver_record` removed. For static values it should be
  replaced with configuration in yaml files. For dynamic values where
  information is sourced from an API or otherwise calculated a custom Source is
  recommended.
* Beta-level support for PowerDnsProvider/LUA scripted records, see
  https://doc.powerdns.com/authoritative/lua-records/index.html for their doc
  and https://gist.github.com/ahupowerdns/1e8bfbba95a277a4fac09cb3654eb2ac for
  some of what's possible.
* Allow configuring mode_of_operation and soa_edit_api via provider parameters

/cc Fixes https://github.com/octodns/octodns-powerdns/issues/26