### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -231,7 +231,9 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': "4.1.10"},
             )
-            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+            provider = PowerDnsProvider(
+                'test', 'non.existent', 'api-key', strict_supports=False
+            )
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 
         # Bad auth
@@ -397,7 +399,9 @@ class TestPowerDnsProvider(TestCase):
                 status_code=200,
                 json={'version': '4.1.0'},
             )
-            provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+            provider = PowerDnsProvider(
+                'test', 'non.existent', 'api-key', strict_supports=False
+            )
 
             missing = Zone(expected.name, [])
             # Find and delete the SPF record


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957