### PR TITLE
Support TLSA record and skip DS record

### DIFF
--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -384,7 +384,7 @@ class PowerDnsBaseProvider(BaseProvider):
             exists = True
             for rrset in resp.json()['rrsets']:
                 _type = rrset['type']
-                if _type in self.SUPPORTS:
+                if _type not in self.SUPPORTS:
                     continue
                 data_for = getattr(self, f'_data_for_{_type}')
                 record_name = zone.hostname_from_fqdn(rrset['name'])

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -384,7 +384,7 @@ class PowerDnsBaseProvider(BaseProvider):
             exists = True
             for rrset in resp.json()['rrsets']:
                 _type = rrset['type']
-                if _type == 'SOA':
+                if _type in self.SUPPORTS:
                     continue
                 data_for = getattr(self, f'_data_for_{_type}')
                 record_name = zone.hostname_from_fqdn(rrset['name'])

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -384,7 +384,11 @@ class PowerDnsBaseProvider(BaseProvider):
             exists = True
             for rrset in resp.json()['rrsets']:
                 _type = rrset['type']
-                if _type not in self.SUPPORTS:
+                _provider_specific_type = f'PowerDnsProvider/{_type}'
+                if (
+                    _type not in self.SUPPORTS
+                    and _provider_specific_type not in self.SUPPORTS
+                ):
                     continue
                 data_for = getattr(self, f'_data_for_{_type}')
                 record_name = zone.hostname_from_fqdn(rrset['name'])

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -37,6 +37,13 @@
     - flags: 0
       tag: issue
       value: ca.unit.tests
+_853._tcp:
+  type: TLSA
+  values:
+  - certificate_association_data: 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
+    certificate_usage: 3
+    matching_type: 1
+    selector: 1
 _imap._tcp:
   ttl: 600
   type: SRV

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -283,6 +283,18 @@
             "ttl": 3600,
             "type": "CAA"
         },
+        {
+            "comments": [],
+            "name": "_853._tcp.unit.tests.",
+            "records": [
+                {
+                    "content": "3 1 1 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+                    "disabled": false
+                }
+            ],
+            "ttl": 3600,
+            "type": "TLSA"
+        },
 	    {
             "comments": [],
             "name": "included.unit.tests.",

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -244,6 +244,18 @@
             "name": "unit.tests.",
             "records": [
                 {
+                    "content": "2371 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+                    "disabled": false
+                }
+            ],
+            "ttl": 3600,
+            "type": "DS"
+        },
+        {
+            "comments": [],
+            "name": "unit.tests.",
+            "records": [
+                {
                     "content": "1.1.1.1.",
                     "disabled": false
                 },

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -284,7 +284,7 @@ class TestPowerDnsProvider(TestCase):
         )
         source.populate(expected)
         expected_n = len(expected.records) - 4
-        self.assertEqual(20, expected_n)
+        self.assertEqual(21, expected_n)
 
         # No diffs == no changes
         with requests_mock() as mock:
@@ -292,7 +292,7 @@ class TestPowerDnsProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEqual(20, len(zone.records))
+            self.assertEqual(21, len(zone.records))
             changes = expected.changes(zone, provider)
             self.assertEqual(0, len(changes))
 
@@ -389,7 +389,7 @@ class TestPowerDnsProvider(TestCase):
             'test', join(dirname(__file__), 'config'), supports_root_ns=False
         )
         source.populate(expected)
-        self.assertEqual(24, len(expected.records))
+        self.assertEqual(25, len(expected.records))
 
         # A small change to a single record
         with requests_mock() as mock:


### PR DESCRIPTION
Adding support for the TLSA record which is supported by octodns.
octodns doesn't (yet) support DS record so skip those like it is done for SOA