### PR TITLE
Update README for newest versions and remove `nameserver_*` values from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ providers:
       port: 8081
       # The api key that grans access (required, example is using an env var)
       api_key: env/POWERDNS_API_KEY
-      # The nameservers to use for this provider (optional, default unmanaged)
-      nameserver_values:
-          - 1.2.3.4.
-          - 1.2.3.5.
-      # The nameserver record TTL when managed, (optional, default 600)
-      nameserver_ttl: 300
 ```
 
 ### Support Information

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
 
 ```
 # Start with the latest versions and don't just copy what's here
-octodns==0.9.14
-octodns-powerdns==0.0.1
-requests==2.26.0
+octodns==0.9.21
+octodns-powerdns==0.0.3
+requests==2.31.0
 ```
 
 ##### SHAs
 
 ```
 # Start with the latest/specific versions and don't just copy what's here
--e git+https://git@github.com/octodns/octodns.git@9da19749e28f68407a1c246dfdf65663cdc1c422#egg=octodns
--e git+https://git@github.com/octodns/octodns-powerdns.git@ec9661f8b335241ae4746eea467a8509205e6a30#egg=octodns_powerdns
-requests==2.26.0
+-e git+https://git@github.com/octodns/octodns.git@67ea0b0ea7961e37b028cfe21c463fa3e5090c8f#egg=octodns
+-e git+https://git@github.com/octodns/octodns-powerdns.git@e33349e5edfe4e12a1d179a32a5f70a8ec4c2aad#egg=octodns_powerdns
+requests==2.31.0
 ```
 
 ### Configuration


### PR DESCRIPTION
An update to the README.md, used the commit hash SHAs from the release commits of each octodns and octodns-powerdns.

We're using `requests=2.31.0` successfully.

`nameserver_` options got removed in `0.0.2` for the root NS support, thus removing.