### PR TITLE
Rework mode_of_operation handling to avoid API calls during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.4 - 2023-??-?? - ???
+
+* Rework mode_of_operation to be fetched on-demand rather than during __init__
+  so that the provider can be created w/o access to or credentials for the
+  server. This should allow things like octodns-validate w/o connectivity.
+
 ## v0.0.3 - 2022-12-22 - TLSA
 
 * Add support for TLSA records

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -207,21 +207,25 @@ class TestPowerDnsProvider(TestCase):
                     'api-key',
                     soa_edit_api='inception-increment',
                 )
-            self.assertTrue(
-                '"soa_edit_api" - possibile values:' in str(ctx.exception)
-            )
+            self.assertTrue('invalid soa_edit_api', str(ctx.exception))
 
             # "Primary" is available since pdns v4.5
             with self.assertRaises(ValueError) as ctx:
-                PowerDnsProvider(
+                provider = PowerDnsProvider(
                     'test',
                     'non.existent',
                     'api-key',
                     mode_of_operation='primary',
                 )
-            self.assertTrue(
-                '"mode_of_operation" - possible values:' in str(ctx.exception)
-            )
+                provider.mode_of_operation()
+            self.assertTrue('invalid mode_of_operation' in str(ctx.exception))
+
+            # "foo" is never a valid option
+            with self.assertRaises(ValueError) as ctx:
+                provider = PowerDnsProvider(
+                    'test', 'non.existent', 'api-key', mode_of_operation='foo'
+                )
+            self.assertTrue('invalid mode_of_operation' in str(ctx.exception))
 
     def test_provider(self):
         # Test version detection


### PR DESCRIPTION
This reworks `PowerDnsProvider` to to a first pass at validating `mode_of_operation` during `__init__` assuming that we're running a version of pdns that allows the full set of values. It will only make the API call to get the version and fully vet the value at the point at which it's going to be used, if any. 

This avoids making API calls during `__init__` and further will avoid making the call at all unless it's strictly needed to vet this or some other value.

It'd be nice to get the complete vetting done during `__init__`, that's the one downside of this approach, but I think the upside of avoiding API calls just to create the provider is worth it. Open to other's thoughts. 

/cc Fixes https://github.com/octodns/octodns-powerdns/issues/39, assuming we're happy with the route taken
/cc @fjaeckel for 👍 / 👎  since I can't request a review directly