### PR TITLE
v0.0.4 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2023-??-?? - ???
+## v0.0.4 - 2023-08-03 - Stay off the network unless you really need it
 
 * Rework mode_of_operation to be fetched on-demand rather than during __init__
   so that the provider can be created w/o access to or credentials for the

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -14,7 +14,7 @@ from octodns.record import Record
 
 from .record import PowerDnsLuaRecord
 
-__VERSION__ = '0.0.3'
+__VERSION__ = '0.0.4'
 
 
 def _escape_unescaped_semicolons(value):


### PR DESCRIPTION
## v0.0.4 - 2023-08-03 - Stay off the network unless you really need it

* Rework mode_of_operation to be fetched on-demand rather than during __init__
  so that the provider can be created w/o access to or credentials for the
  server. This should allow things like octodns-validate w/o connectivity.

/cc @fjaeckel 