### PR TITLE
accept ssl_verify keyword from user and disable if its not provided

### DIFF
--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -1,3 +1,4 @@
+
 #
 #
 #
@@ -69,7 +70,7 @@ class PowerDnsBaseProvider(BaseProvider):
         api_key,
         port=8081,
         scheme="http",
-        ssl_verify=True,
+        ssl_verify=False,
         timeout=TIMEOUT,
         soa_edit_api='default',
         mode_of_operation='master',
@@ -662,6 +663,8 @@ class PowerDnsProvider(PowerDnsBaseProvider):
         host,
         api_key,
         port=8081,
+        scheme="http",
+        ssl_verify=False,
         nameserver_values=None,
         nameserver_ttl=None,
         *args,
@@ -678,7 +681,7 @@ class PowerDnsProvider(PowerDnsBaseProvider):
             nameserver_ttl,
         )
         super().__init__(
-            id, host=host, api_key=api_key, port=port, *args, **kwargs
+            id, host=host, api_key=api_key, port=port, scheme=scheme, ssl_verify=ssl_verify, *args, **kwargs
         )
 
         if nameserver_values or nameserver_ttl:


### PR DESCRIPTION
This change resolves issue #46 by setting adding ssl_verify to "**__init__**" in the class **PowerDnsProvider** and changed the default to False for considering most of administrators are probably using it as an internal service and deploying self signed certificate. 

I've tried it for my own case and it works. Please let me know if it looks dumb, since I am no expert in python or any other programming language. This is my sincere effort to contribute a project I use a lot. 