### PR TITLE
Support both old and new DS field names

### DIFF
--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -10,7 +10,8 @@ from requests import HTTPError, Session
 from octodns import __VERSION__ as octodns_version
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
-from octodns.record.ds import DsValue, Record
+from octodns.record import Record
+from octodns.record.ds import DsValue
 
 from .record import PowerDnsLuaRecord
 


### PR DESCRIPTION
This reworks octodns-powerdns's handling of DS fields so that it's dynamically compabile with both the old (wrong) field names and new corrected ones. Once this is merged we should be able to cut a release that will be comptible with the past and future DS record support cleanly without any further effort required. 

/cc https://github.com/octodns/octodns-powerdns/pull/49 which added DS support
/cc https://github.com/octodns/octodns-powerdns/pull/50/ which this replaces
/cc https://github.com/octodns/octodns/pull/1065 which this updates octodns-powerdns to transparently handle