### PR TITLE
Fix incorrect url formatting when port is a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## v0.0.6 - 2023-??-?? - ???
+## v0.0.6 - 2024-??-?? - ???
 
 * DS Record support added
+* Fix for url formatting of port when it's of type float
 
 ## v0.0.5 - 2023-09-12 - Known your zones
 

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -95,7 +95,7 @@ class PowerDnsBaseProvider(BaseProvider):
             )
 
         self.host = host
-        self.port = port
+        self.port = int(port)
         self.scheme = scheme
         self.timeout = timeout
         self.notify = notify
@@ -130,7 +130,7 @@ class PowerDnsBaseProvider(BaseProvider):
         self.log.debug('_request: method=%s, path=%s', method, path)
 
         url = (
-            f'{self.scheme}://{self.host}:{self.port}/api/v1/servers/'
+            f'{self.scheme}://{self.host}:{self.port:d}/api/v1/servers/'
             f'localhost/{path}'.rstrip('/')
         )
         # Strip trailing / from url.

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -231,12 +231,18 @@ class TestPowerDnsProvider(TestCase):
         # Test version detection
         with requests_mock() as mock:
             mock.get(
-                'http://non.existent:8081/api/v1/servers/localhost',
+                'http://non.existent:8082/api/v1/servers/localhost',
                 status_code=200,
                 json={'version': "4.1.10"},
             )
             provider = PowerDnsProvider(
-                'test', 'non.existent', 'api-key', strict_supports=False
+                'test',
+                'non.existent',
+                'api-key',
+                strict_supports=False,
+                # specifically testing a float here to make sure it doesn't
+                # include the .1 when applied to the url
+                port=8082.1,
             )
             self.assertEqual(provider.powerdns_version, [4, 1, 10])
 


### PR DESCRIPTION
Converts to int and int formats in string.

/cc https://github.com/octodns/octodns/issues/1148#issuecomment-1984919619