### PR TITLE
encode zone names in url paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.? - 2024-??-?? - ???
+
+* Support for fully managing zones with special characters in their names, e.g.
+  128/26.2.0.192.in-addr.arpa. added.
+
 ## v0.0.6 - 2024-03-08 - Get port type straight
 
 * DS Record support added

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -19,6 +19,7 @@ from octodns.zone import Zone
 from octodns_powerdns import (
     PowerDnsBaseProvider,
     PowerDnsProvider,
+    _encode_zone_name,
     _escape_unescaped_semicolons,
 )
 from octodns_powerdns.record import PowerDnsLuaRecord, _PowerDnsLuaValue
@@ -792,3 +793,11 @@ class TestPowerDnsLuaRecord(TestCase):
         # list w/a bad value
         got = _PowerDnsLuaValue.validate([val, {}], PowerDnsLuaRecord._type)
         self.assertEqual(['missing type', 'missing script'], got)
+
+    def test_encode_zone_name(self):
+        for expected, value in (
+            ('unit.tests.', 'unit.tests.'),
+            ('another_one.unit.tests.', 'another_one.unit.tests.'),
+            ('128=2F26.2.0.192.in-addr.arpa.', '128/26.2.0.192.in-addr.arpa.'),
+        ):
+            self.assertEqual(expected, _encode_zone_name(value))


### PR DESCRIPTION
Hi
We host several RFC2317[^1] zones such as "128/26.2.0.192.in-addr.arpa.". Normal operation like creating the zone or adding/updating new entries can be done with the plugin.  If you activate the notify option, the following error is displayed because the zone name is not encoded:

````
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://POWERNDNS/api/v1/servers/localhost/zones/128/26.2.0.192.in-addr.arpa./notify
````

This PR adds URL encoding for the zone name.

Powerdns uses a special encoding for URLs. Instead of "%2F" for a slash, the slash must be encoded with "=2F". (This must be done in version 4.7.3 from Debian, from version >= 4.8 Powerdns accepts “%2F” and “=2F” as path argument. The output of "/api/v1/servers/localhost/zones" still shows the zone URL with "=2F")

[^1]: https://datatracker.ietf.org/doc/html/rfc2317#section-4