### PR TITLE
v0.0.7 changelog update & version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.? - 2024-??-?? - ???
+## v0.0.7 - 2024-08-28 - Less picky about names
 
 * Support for fully managing zones with special characters in their names, e.g.
   128/26.2.0.192.in-addr.arpa. added.

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
 from .record import PowerDnsLuaRecord
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.6'
+__version__ = __VERSION__ = '0.0.7'
 
 
 def _encode_zone_name(name):


### PR DESCRIPTION
## v0.0.7 - 2024-08-28 - Less picky about names

* Support for fully managing zones with special characters in their names, e.g.
  128/26.2.0.192.in-addr.arpa. added.