### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 ### Notedworthy Changes:
 

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover
 from .record import PowerDnsLuaRecord
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def _encode_zone_name(name):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.0

### Notedworthy Changes:

* `SPF` record support removed, records should be migrated to `TXT` before
  upgrading.
* DS properties "algorithm", "flags", "public_key", and "protocol" support
  removed
* Requires octoDNS >= 1.5.0