### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/0176ad7731a9428a92b794db746f0568.md
+++ b/.changelog/0176ad7731a9428a92b794db746f0568.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Correct readme typo

--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/1db55265439742dd92ea777023417165.md
+++ b/.changelog/1db55265439742dd92ea777023417165.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/220d9ce126f842cf9c61515f8d035bba.md
+++ b/.changelog/220d9ce126f842cf9c61515f8d035bba.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/3a74654606ac4e8ebc5914d5a6dae750.md
+++ b/.changelog/3a74654606ac4e8ebc5914d5a6dae750.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/6dc54cc66333401b927beb7ab136939e.md
+++ b/.changelog/6dc54cc66333401b927beb7ab136939e.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/822e7123fe7c40b7b8edc4a406445101.md
+++ b/.changelog/822e7123fe7c40b7b8edc4a406445101.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix ns1 type-o in script/format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/b57b6b9cc7a94aa6976fccc1c3376f83.md
+++ b/.changelog/b57b6b9cc7a94aa6976fccc1c3376f83.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/c11eef73fe934a6681499fb3f6f61e00.md
+++ b/.changelog/c11eef73fe934a6681499fb3f6f61e00.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add support for URI record type

--- a/.changelog/dc4409765e0c4ffe824fc4d6208ec76d.md
+++ b/.changelog/dc4409765e0c4ffe824fc4d6208ec76d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ea6268b4c5b542ebb35a618bc66032fe.md
+++ b/.changelog/ea6268b4c5b542ebb35a618bc66032fe.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/f9e357b2820b413f95f7dcae13b29be0.md
+++ b/.changelog/f9e357b2820b413f95f7dcae13b29be0.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Add support for URI record type - [#82](https://github.com/octodns/octodns-powerdns/pull/82)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#83](https://github.com/octodns/octodns-powerdns/pull/83)
+
 ## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 ### Notedworthy Changes:

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
 from .record import PowerDnsLuaRecord
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 def _encode_zone_name(name):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Add support for URI record type - [#82](https://github.com/octodns/octodns-powerdns/pull/82)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#83](https://github.com/octodns/octodns-powerdns/pull/83)

