### PR TITLE
Add configurable server_id parameter for PowerDNS API

### DIFF
--- a/.changelog/8a90cda81bd449afa72922321f37ba23.md
+++ b/.changelog/8a90cda81bd449afa72922321f37ba23.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add configurable server_id parameter for PowerDNS API

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ providers:
       # ssl_verify: true
       # Send DNS NOTIFY to secondary servers after change (optional, default false)
       # notify: false
+      # The PowerDNS server id used in API URLs (optional, default localhost)
+      # server_id: localhost
 ```
 
 ### Support Information

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -110,6 +110,7 @@ class PowerDnsBaseProvider(BaseProvider):
         soa_edit_api='default',
         mode_of_operation='master',
         notify=False,
+        server_id='localhost',
         *args,
         **kwargs,
     ):
@@ -128,6 +129,7 @@ class PowerDnsBaseProvider(BaseProvider):
         self.scheme = scheme
         self.timeout = timeout
         self.notify = notify
+        self.server_id = server_id
 
         self._powerdns_version = None
 
@@ -160,7 +162,7 @@ class PowerDnsBaseProvider(BaseProvider):
 
         url = (
             f'{self.scheme}://{self.host}:{self.port:d}/api/v1/servers/'
-            f'localhost/{path}'.rstrip('/')
+            f'{self.server_id}/{path}'.rstrip('/')
         )
         # Strip trailing / from url.
         resp = self._sess.request(method, url, json=data, timeout=self.timeout)

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -228,6 +228,24 @@ class TestPowerDnsProvider(TestCase):
                 )
             self.assertTrue('invalid mode_of_operation' in str(ctx.exception))
 
+    def test_server_id(self):
+        # Default server_id is "localhost"
+        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+        self.assertEqual(provider.server_id, 'localhost')
+
+        # Custom server_id is used in the API URL
+        with requests_mock() as mock:
+            mock.get(
+                'http://non.existent:8081/api/v1/servers/custom-id',
+                status_code=200,
+                json={'version': "4.5.0"},
+            )
+            provider = PowerDnsProvider(
+                'test', 'non.existent', 'api-key', server_id='custom-id'
+            )
+            self.assertEqual(provider.server_id, 'custom-id')
+            self.assertEqual(provider.powerdns_version, [4, 5, 0])
+
     def test_provider(self):
         # Test version detection
         with requests_mock() as mock:


### PR DESCRIPTION
      # The PowerDNS server id used in API URLs (optional, default localhost)
      # server_id: localhost

/cc Fixes #99 