### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/7d9eab99c04f4a86a981aec13eaebe3f.md
+++ b/.changelog/7d9eab99c04f4a86a981aec13eaebe3f.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -201,7 +201,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -325,7 +325,10 @@ class TestPowerDnsProvider(TestCase):
 
         expected = Zone('unit.tests.', [])
         source = YamlProvider(
-            'test', join(dirname(__file__), 'config'), supports_root_ns=False
+            'test',
+            join(dirname(__file__), 'config'),
+            supports_root_ns=False,
+            escaped_semicolons=False,
         )
         source.populate(expected)
         expected_n = len(expected.records) - 4
@@ -431,7 +434,10 @@ class TestPowerDnsProvider(TestCase):
     def test_small_change(self):
         expected = Zone('unit.tests.', [])
         source = YamlProvider(
-            'test', join(dirname(__file__), 'config'), supports_root_ns=False
+            'test',
+            join(dirname(__file__), 'config'),
+            supports_root_ns=False,
+            escaped_semicolons=False,
         )
         source.populate(expected)
         self.assertEqual(29, len(expected.records))
@@ -489,7 +495,10 @@ class TestPowerDnsProvider(TestCase):
     def test_notify(self):
         expected = Zone('unit.tests.', [])
         source = YamlProvider(
-            'test', join(dirname(__file__), 'config'), supports_root_ns=False
+            'test',
+            join(dirname(__file__), 'config'),
+            supports_root_ns=False,
+            escaped_semicolons=False,
         )
         source.populate(expected)
 


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419