### PR TITLE
Add subnet/CIDR-based routing support for dynamic records

### DIFF
--- a/.changelog/c1cf004b594d44288d6de36ee6d2726f.md
+++ b/.changelog/c1cf004b594d44288d6de36ee6d2726f.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add subnet/CIDR-based routing support for dynamic records; subnet rules are encoded using PowerDNS's netmask() Lua helper

--- a/README.md
+++ b/README.md
@@ -76,20 +76,26 @@ PowerDnsProvider supports dynamic A, AAAA, and CNAME records by generating
 [PowerDNS LUA records](https://doc.powerdns.com/authoritative/lua-records/index.html)
 that route answers via the `continent()`, `country()`, and `region()` geo
 helpers backed by the
-[geoipbackend](https://doc.powerdns.com/authoritative/backends/geoip.html).
+[geoipbackend](https://doc.powerdns.com/authoritative/backends/geoip.html),
+and via the `netmask({...})` helper for subnet/CIDR-based routing.
 Pool values are emitted as `pickwhashed({{weight, value}, ...})`; pool
 fallback chains are flattened into the selected pool's value list at encode
 time.
 
-The full octoDNS dynamic payload (pools, rules, weights, fallback) is
+Subnet/CIDR-based rules are emitted using PowerDNS's `netmask({...})` helper,
+which matches the client IP against the listed CIDRs and does **not** require
+the geoip backend. A rule may combine subnets and geos; the client matches if
+it falls in any listed subnet **or** matches any listed geo. As required by
+octoDNS, subnet-based rules take precedence over geo-only rules — ensured
+naturally by the `if/elseif` chain ordering.
+
+The full octoDNS dynamic payload (pools, rules, weights, fallback, subnets) is
 embedded in a leading Lua comment as a base64-encoded JSON blob so that
 `populate` after an `apply` round-trips cleanly — octodns-powerdns parses
 that marker rather than trying to read back the generated Lua.
 
 ##### Out of scope
 
-- Subnet-based rules (`SUPPORTS_DYNAMIC_SUBNETS=False`) — octoDNS core strips
-  them before they reach the provider.
 - Per-value pool status (`SUPPORTS_POOL_VALUE_STATUS=False`) — all values are
   treated as `obey`.
 - Manually-authored LUA records (`PowerDnsProvider/LUA`) — still supported
@@ -98,11 +104,14 @@ that marker rather than trying to read back the generated Lua.
 ##### Server requirements
 
 For dynamic records to actually resolve correctly, the PowerDNS server must
-have:
+have `enable-lua-records=yes` (or `shared`). Geo-based routing additionally
+requires:
 
-1. `enable-lua-records=yes` (or `shared`)
-2. The `geoipbackend` loaded via `launch=...,geoip` **and** a MaxMind database
+1. The `geoipbackend` loaded via `launch=...,geoip` **and** a MaxMind database
    configured via `geoip-database-files=...`
+
+Subnet/CIDR-based routing uses `netmask()` which is a built-in Lua function
+and works with just `enable-lua-records` — no geoip backend is needed.
 
 **Silent-failure warning:** if `enable-lua-records` is on but the geoip
 backend is not loaded, PowerDNS will happily serve the generated Lua but
@@ -110,6 +119,12 @@ every `continent()`/`country()` call will return an empty string — every
 request falls through to the catchall pool. octodns-powerdns probes
 `GET /api/v1/servers/{server_id}/config` once per run to check both settings
 and disables dynamic support (logging a warning) if either is missing.
+
+> [!NOTE]
+> The probe currently gates **all** dynamic support (including subnet-only
+> records) on the geoip backend being configured. If you are using only
+> subnet-based routing and do not have geoip configured, set
+> `enable_dynamic: true` on the provider to force dynamic support on.
 
 If the probe can't run (for example, the API key lacks access to `config`),
 set `enable_dynamic: true` on the provider to force dynamic support on. Set

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -58,7 +58,7 @@ def _escape_unescaped_semicolons(value):
 
 class PowerDnsBaseProvider(BaseProvider):
     SUPPORTS_GEO = False
-    SUPPORTS_DYNAMIC_SUBNETS = False
+    SUPPORTS_DYNAMIC_SUBNETS = True
     SUPPORTS_POOL_VALUE_STATUS = False
     SUPPORTS_ROOT_NS = True
     SUPPORTS_MULTIVALUE_PTR = True

--- a/octodns_powerdns/dynamic.py
+++ b/octodns_powerdns/dynamic.py
@@ -27,8 +27,18 @@ def _geo_condition(code):
     return f"continent('{parsed['continent_code']}')"
 
 
-def _rule_condition(geos):
-    parts = [f'({_geo_condition(g)})' for g in geos]
+def _subnet_condition(subnets):
+    entries = ', '.join(f"'{s}'" for s in subnets)
+    return f'netmask({{{entries}}})'
+
+
+def _rule_condition(data):
+    parts = []
+    subnets = data.get('subnets') or []
+    if subnets:
+        parts.append(f'({_subnet_condition(subnets)})')
+    for g in data.get('geos') or []:
+        parts.append(f'({_geo_condition(g)})')
     return ' or '.join(parts)
 
 
@@ -72,19 +82,14 @@ def encode(record):
     conditional = []
     for rule in dynamic.rules:
         data = rule.data
-        if data.get('subnets'):
-            raise ProviderException(
-                f'{record.fqdn} {record._type}: subnet rules are not supported'
-            )
-        geos = data.get('geos') or []
-        if not geos:
+        if not (data.get('geos') or data.get('subnets')):
             if catchall is not None:
                 raise ProviderException(
                     f'{record.fqdn} {record._type}: multiple catchall rules'
                 )
             catchall = data['pool']
             continue
-        conditional.append((geos, data['pool']))
+        conditional.append(data)
 
     if catchall is None:
         raise ProviderException(
@@ -92,10 +97,12 @@ def encode(record):
         )
 
     lines = [f';{DYNAMIC_MARKER}{_marker_payload(record)}']
-    for i, (geos, pool) in enumerate(conditional):
+    for i, data in enumerate(conditional):
         keyword = 'if' if i == 0 else 'elseif'
-        cond = _rule_condition(geos)
-        lines.append(f'{keyword} {cond} then return {_pool_lua(pool, dynamic)}')
+        cond = _rule_condition(data)
+        lines.append(
+            f'{keyword} {cond} then return {_pool_lua(data["pool"], dynamic)}'
+        )
     if conditional:
         lines.append('end')
     lines.append(f'return {_pool_lua(catchall, dynamic)}')

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -100,6 +100,8 @@ dyn:
     - geos:
       - EU
       pool: eu
+      subnets:
+      - 10.0.0.0/8
     - pool: default
   ttl: 60
   type: A

--- a/tests/fixtures/powerdns-full-data.json
+++ b/tests/fixtures/powerdns-full-data.json
@@ -312,7 +312,7 @@
             "name": "dyn.unit.tests.",
             "records": [
                 {
-                    "content": "A \";-- octodns-dynamic:v1:eyJwb29scyI6eyJkZWZhdWx0Ijp7ImZhbGxiYWNrIjpudWxsLCJ2YWx1ZXMiOlt7InN0YXR1cyI6Im9iZXkiLCJ2YWx1ZSI6IjUuNS41LjUiLCJ3ZWlnaHQiOjF9XX0sImV1Ijp7ImZhbGxiYWNrIjpudWxsLCJ2YWx1ZXMiOlt7InN0YXR1cyI6Im9iZXkiLCJ2YWx1ZSI6IjEuMS4xLjEiLCJ3ZWlnaHQiOjF9XX19LCJydWxlcyI6W3siZ2VvcyI6WyJFVSJdLCJwb29sIjoiZXUifSx7InBvb2wiOiJkZWZhdWx0In1dfQ==\nif (continent('EU')) then return pickwhashed({{1, '1.1.1.1'}})\nend\nreturn pickwhashed({{1, '5.5.5.5'}})\"",
+                    "content": "A \";-- octodns-dynamic:v1:eyJwb29scyI6eyJkZWZhdWx0Ijp7ImZhbGxiYWNrIjpudWxsLCJ2YWx1ZXMiOlt7InN0YXR1cyI6Im9iZXkiLCJ2YWx1ZSI6IjUuNS41LjUiLCJ3ZWlnaHQiOjF9XX0sImV1Ijp7ImZhbGxiYWNrIjpudWxsLCJ2YWx1ZXMiOlt7InN0YXR1cyI6Im9iZXkiLCJ2YWx1ZSI6IjEuMS4xLjEiLCJ3ZWlnaHQiOjF9XX19LCJydWxlcyI6W3siZ2VvcyI6WyJFVSJdLCJwb29sIjoiZXUiLCJzdWJuZXRzIjpbIjEwLjAuMC4wLzgiXX0seyJwb29sIjoiZGVmYXVsdCJ9XX0=\nif (netmask({'10.0.0.0/8'})) or (continent('EU')) then return pickwhashed({{1, '1.1.1.1'}})\nend\nreturn pickwhashed({{1, '5.5.5.5'}})\"",
                     "disabled": false
                 }
             ],

--- a/tests/test_octodns_powerdns_dynamic.py
+++ b/tests/test_octodns_powerdns_dynamic.py
@@ -188,7 +188,7 @@ class TestDynamicEncode(TestCase):
             encode(rec)
         self.assertIn('non-dynamic', str(ctx.exception))
 
-    def test_encode_subnet_rule_raises(self):
+    def test_encode_subnet_only_rule(self):
         rec = _record(
             values=['5.5.5.5'],
             dynamic={
@@ -202,9 +202,75 @@ class TestDynamicEncode(TestCase):
                 ],
             },
         )
-        with self.assertRaises(ProviderException) as ctx:
-            encode(rec)
-        self.assertIn('subnet', str(ctx.exception))
+        script = encode(rec)
+        self.assertIn("if (netmask({'10.0.0.0/8'})) then", script)
+        self.assertIn("return pickwhashed({{1, '1.1.1.1'}})", script)
+        self.assertIn("return pickwhashed({{1, '5.5.5.5'}})", script)
+
+    def test_encode_multi_subnet(self):
+        rec = _record(
+            values=['5.5.5.5'],
+            dynamic={
+                'pools': {
+                    'p': {'values': [{'value': '1.1.1.1'}]},
+                    'default': {'values': [{'value': '5.5.5.5'}]},
+                },
+                'rules': [
+                    {'subnets': ['10.0.0.0/8', '192.168.0.0/16'], 'pool': 'p'},
+                    {'pool': 'default'},
+                ],
+            },
+        )
+        script = encode(rec)
+        # core sorts subnets lexicographically; '10...' < '192...'
+        self.assertIn(
+            "if (netmask({'10.0.0.0/8', '192.168.0.0/16'})) then", script
+        )
+
+    def test_encode_subnet_and_geo_rule(self):
+        rec = _record(
+            values=['5.5.5.5'],
+            dynamic={
+                'pools': {
+                    'p': {'values': [{'value': '1.1.1.1'}]},
+                    'default': {'values': [{'value': '5.5.5.5'}]},
+                },
+                'rules': [
+                    {'subnets': ['10.0.0.0/8'], 'geos': ['EU'], 'pool': 'p'},
+                    {'pool': 'default'},
+                ],
+            },
+        )
+        script = encode(rec)
+        # subnet part comes first, then geo; OR-joined
+        self.assertIn(
+            "if (netmask({'10.0.0.0/8'})) or (continent('EU')) then", script
+        )
+
+    def test_encode_subnet_before_geo_ordering(self):
+        # core ordering: subnet-only → geo-only → catchall;
+        # the if/elseif chain must reflect that order
+        rec = _record(
+            values=['5.5.5.5'],
+            dynamic={
+                'pools': {
+                    'ten': {'values': [{'value': '1.1.1.1'}]},
+                    'eu': {'values': [{'value': '2.2.2.2'}]},
+                    'default': {'values': [{'value': '5.5.5.5'}]},
+                },
+                'rules': [
+                    {'subnets': ['10.0.0.0/8'], 'pool': 'ten'},
+                    {'geos': ['EU'], 'pool': 'eu'},
+                    {'pool': 'default'},
+                ],
+            },
+        )
+        script = encode(rec)
+        lines = script.splitlines()
+        # marker, if (subnet), elseif (geo), end, return
+        self.assertTrue(lines[1].startswith("if (netmask({'10.0.0.0/8'}))"))
+        self.assertTrue(lines[2].startswith("elseif (continent('EU'))"))
+        self.assertEqual('end', lines[3])
 
     def test_encode_multiple_catchalls_raises(self):
         # Hand-craft a record then poke an extra catchall rule in — octoDNS
@@ -354,6 +420,30 @@ class TestDynamicRoundTrip(TestCase):
                     'default': {'values': [{'value': 'default.example.com.'}]},
                 },
                 'rules': [{'geos': ['EU'], 'pool': 'eu'}, {'pool': 'default'}],
+            },
+        )
+        self._round_trip(rec)
+
+    def test_subnets(self):
+        rec = _record(
+            values=['5.5.5.5'],
+            dynamic={
+                'pools': {
+                    'ten': {'values': [{'value': '1.1.1.1'}]},
+                    'eu': {'values': [{'value': '2.2.2.2'}]},
+                    'default': {'values': [{'value': '5.5.5.5'}]},
+                },
+                'rules': [
+                    # subnet-only rule comes first (core ordering)
+                    {'subnets': ['10.0.0.0/8'], 'pool': 'ten'},
+                    # subnet+geo rule (core ordering: after subnet-only)
+                    {
+                        'subnets': ['172.16.0.0/12'],
+                        'geos': ['EU'],
+                        'pool': 'eu',
+                    },
+                    {'pool': 'default'},
+                ],
             },
         )
         self._round_trip(rec)


### PR DESCRIPTION
Builds on #101.

## Summary

- Sets `SUPPORTS_DYNAMIC_SUBNETS=True` so octoDNS core passes subnet rules through to the provider instead of stripping them.
- Adds `_subnet_condition()` to emit `netmask({'cidr', ...})` Lua conditions; refactors `_rule_condition` to take the full rule dict and OR-join subnet and geo parts (subnet part first).
- A rule with both `subnets` and `geos` matches if the client falls in any listed subnet **or** any listed geo — consistent with the octoDNS-documented semantics and how other providers (ns1, route53) handle combined rules.
- Subnet-only rules precede geo-only rules in the `if/elseif` chain, satisfying octoDNS's specificity requirement naturally via core's enforced rule ordering.
- `netmask()` is a built-in PowerDNS Lua function and does not require the geoip backend (noted in docs; geoip probe limitation flagged as a follow-up).

## Test plan

- [x] `./script/lint`
- [x] `./script/format --check`
- [x] `./script/test` — 63 passed
- [x] `./script/coverage` — 100% branch coverage on `__init__.py`, `dynamic.py`, `record.py`