### PR TITLE
Fix LUA record validator deprecation warning

### DIFF
--- a/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
+++ b/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix LUA record validator deprecation warning

--- a/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
+++ b/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
@@ -1,4 +1,4 @@
 ---
-type: patch
+type: none
 ---
 Fix LUA record validator deprecation warning

--- a/octodns_powerdns/record.py
+++ b/octodns_powerdns/record.py
@@ -2,11 +2,15 @@ from octodns.equality import EqualityTupleMixin
 from octodns.record import Record, ValuesMixin
 
 try:  # pragma: no cover
-    from octodns.record.validator import ValueValidator
+    import octodns.record.validator
 
-    _HAS_VALUE_VALIDATOR = True
+    _HAS_VALUE_VALIDATOR = hasattr(octodns.record.validator, 'ValueValidator')
+    _HAS_VALIDATION_REASON = hasattr(
+        octodns.record.validator, 'ValidationReason'
+    )
 except ImportError:  # pragma: no cover
     _HAS_VALUE_VALIDATOR = False
+    _HAS_VALIDATION_REASON = False
 
 
 def _validate_powerdns_lua_values(data):
@@ -25,9 +29,17 @@ def _validate_powerdns_lua_values(data):
 
 if _HAS_VALUE_VALIDATOR:  # pragma: no cover
 
-    class _PowerDnsLuaValueValidator(ValueValidator):
+    class _PowerDnsLuaValueValidator(octodns.record.validator.ValueValidator):
         def validate(self, value_cls, data, _type):
-            return _validate_powerdns_lua_values(data)
+            reasons = _validate_powerdns_lua_values(data)
+            if _HAS_VALIDATION_REASON:
+                return [
+                    octodns.record.validator.ValidationReason(
+                        r, validator_id=self.id
+                    )
+                    for r in reasons
+                ]
+            return reasons
 
 
 class _PowerDnsLuaValue(EqualityTupleMixin, dict):

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -1035,9 +1035,7 @@ class TestPowerDnsLuaRecord(TestCase):
                 'lua',
                 {'type': PowerDnsLuaRecord._type, 'ttl': 42, 'values': []},
             )
-        self.assertEqual(
-            'at least one value required', ctx.exception.reasons[0]
-        )
+        self.assertIn('at least one value required', ctx.exception.reasons[0])
 
         # value missing type
         with self.assertRaises(ValidationError) as ctx:
@@ -1050,7 +1048,7 @@ class TestPowerDnsLuaRecord(TestCase):
                     'value': {'script': ''},
                 },
             )
-        self.assertEqual('missing type', ctx.exception.reasons[0])
+        self.assertIn('missing type', ctx.exception.reasons[0])
 
         # value missing script
         with self.assertRaises(ValidationError) as ctx:
@@ -1063,7 +1061,7 @@ class TestPowerDnsLuaRecord(TestCase):
                     'value': {'type': 'A'},
                 },
             )
-        self.assertEqual('missing script', ctx.exception.reasons[0])
+        self.assertIn('missing script', ctx.exception.reasons[0])
 
         # valid record with a single value
         lua = Record.new(
@@ -1110,6 +1108,26 @@ class TestPowerDnsLuaRecord(TestCase):
         # smoke tests
         lua.__repr__()
         hash(lua.values[0])
+
+    def test_legacy_validation_reasons(self):
+        import octodns_powerdns.record
+
+        # Save the original _HAS_VALIDATION_REASON
+        original = getattr(
+            octodns_powerdns.record, '_HAS_VALIDATION_REASON', False
+        )
+        octodns_powerdns.record._HAS_VALIDATION_REASON = False
+        try:
+            from octodns_powerdns.record import _PowerDnsLuaValueValidator
+
+            validator = _PowerDnsLuaValueValidator('powerdns-lua-value')
+            reasons = validator.validate(
+                _PowerDnsLuaValue, [], PowerDnsLuaRecord._type
+            )
+            self.assertEqual(['at least one value required'], reasons)
+        finally:
+            # Restore
+            octodns_powerdns.record._HAS_VALIDATION_REASON = original
 
     def test_lua_validate(self):
         val = {'type': 'A', 'script': ''}


### PR DESCRIPTION
Separately import ValidationReason and only return the object if available, maintaining backward compatibility with older versions of octodns.

/cc https://github.com/octodns/octodns/pull/1443