### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/0a41f23f012a4414be59d2fe68720547.md
+++ b/.changelog/0a41f23f012a4414be59d2fe68720547.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add a quick pass at AGENTS.md that mostly deferrs to core's

--- a/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
+++ b/.changelog/5121a1b7ab784e8fb3a98e9a5eb7ef48.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix LUA record validator deprecation warning

--- a/.changelog/55c7a4ea83b04243b7da5ce0cb9d2229.md
+++ b/.changelog/55c7a4ea83b04243b7da5ce0cb9d2229.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Quick pass at migrating to Validators, backwards compat

--- a/.changelog/7d9eab99c04f4a86a981aec13eaebe3f.md
+++ b/.changelog/7d9eab99c04f4a86a981aec13eaebe3f.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Explicit non-escaped semicolons for YamlProvider

--- a/.changelog/8825c2282bce4d75b0aab3bb88e3bf77.md
+++ b/.changelog/8825c2282bce4d75b0aab3bb88e3bf77.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/8a90cda81bd449afa72922321f37ba23.md
+++ b/.changelog/8a90cda81bd449afa72922321f37ba23.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add configurable server_id parameter for PowerDNS API

--- a/.changelog/949d60a9ad1d462a94178d43c875beed.md
+++ b/.changelog/949d60a9ad1d462a94178d43c875beed.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/a7131549ea584e8b8eebfccb0645aa75.md
+++ b/.changelog/a7131549ea584e8b8eebfccb0645aa75.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add Dynamic Record Geo Support

--- a/.changelog/b7a8bad10fc145109376bc6d822041bc.md
+++ b/.changelog/b7a8bad10fc145109376bc6d822041bc.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Ignore Value.validate deprecation warning

--- a/.changelog/c1cf004b594d44288d6de36ee6d2726f.md
+++ b/.changelog/c1cf004b594d44288d6de36ee6d2726f.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add subnet/CIDR-based routing support for dynamic records; subnet rules are encoded using PowerDNS's netmask() Lua helper

--- a/.changelog/f9b465e2758b48cc911b1c2c0b3da5e8.md
+++ b/.changelog/f9b465e2758b48cc911b1c2c0b3da5e8.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.0 - 2026-07-10
+
+Minor:
+* Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10 - [#112](https://github.com/octodns/octodns-powerdns/pull/112)
+* Add subnet/CIDR-based routing support for dynamic records; subnet rules are encoded using PowerDNS's netmask() Lua helper - [#108](https://github.com/octodns/octodns-powerdns/pull/108)
+* Add Dynamic Record Geo Support - [#101](https://github.com/octodns/octodns-powerdns/pull/101)
+* Quick pass at migrating to Validators, backwards compat - [#103](https://github.com/octodns/octodns-powerdns/pull/103)
+* Add configurable server_id parameter for PowerDNS API - [#100](https://github.com/octodns/octodns-powerdns/pull/100)
+
 ## 1.1.0 - 2026-04-03
 
 Minor:

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -34,7 +34,7 @@ from .dynamic import encode as _dynamic_encode
 from .record import PowerDnsLuaRecord
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 
 def _encode_zone_name(name):


### PR DESCRIPTION
## 1.2.0 - 2026-07-10

Minor:
* Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10 - [#112](https://github.com/octodns/octodns-powerdns/pull/112)
* Add subnet/CIDR-based routing support for dynamic records; subnet rules are encoded using PowerDNS's netmask() Lua helper - [#108](https://github.com/octodns/octodns-powerdns/pull/108)
* Add Dynamic Record Geo Support - [#101](https://github.com/octodns/octodns-powerdns/pull/101)
* Quick pass at migrating to Validators, backwards compat - [#103](https://github.com/octodns/octodns-powerdns/pull/103)
* Add configurable server_id parameter for PowerDNS API - [#100](https://github.com/octodns/octodns-powerdns/pull/100)

