### PR TITLE
Ignore octoDNS 2.0 deprecation warnings

### DIFF
--- a/.changelog/7b15daa455d24889845df5af38ed9850.md
+++ b/.changelog/7b15daa455d24889845df5af38ed9850.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Ignore octoDNS 2.0 deprecation warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ sections = "FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
   'error',
+  'ignore:.*DEPRECATED.*2.0',
   # required until migrate the check and require octoDNS >= 2.x
   'ignore:`_PowerDnsLuaValue.validate` classmethod is DEPRECATED:DeprecationWarning:octodns.record.base',
 ]


### PR DESCRIPTION
Ignore deprecation warnings for APIs scheduled for removal in octoDNS 2.0 while retaining warning-as-error behavior for all other warnings.

These warnings will be addressed when this module migrates to the octoDNS 2.x APIs.

/cc octodns/octodns#1452 Validate downstream compatibility for the RDATA API migration