### PR TITLE
Migrate to octoDNS's new RDATA API (Rrset/to_rrset/from_rrsets)

### DIFF
--- a/.changelog/e81db20732bf47768df3c703a6d3a434.md
+++ b/.changelog/e81db20732bf47768df3c703a6d3a434.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Migrate to octoDNS's new RDATA API (`Rrset`/`to_rrset`/`from_rrsets`), replacing hand-rolled per-type content parsing/formatting. Requires `octodns>=1.22.0`.

--- a/octodns_powerdns/__init__.py
+++ b/octodns_powerdns/__init__.py
@@ -11,23 +11,7 @@ from requests import HTTPError, Session
 from octodns import __VERSION__ as octodns_version
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
-from octodns.record import Record
-
-try:  # pragma: no cover
-    from octodns.record.https import HttpsValue
-    from octodns.record.svcb import SvcbValue
-
-    SUPPORTS_SVCB = True
-except ImportError:  # pragma: no cover
-    SUPPORTS_SVCB = False
-
-try:  # pragma: no cover
-    from octodns.record.uri import UriValue
-
-    SUPPORTS_URI = True
-except ImportError:  # pragma: no cover
-    SUPPORTS_URI = False
-
+from octodns.record import Record, Rrset
 
 from .dynamic import decode as _dynamic_decode
 from .dynamic import encode as _dynamic_encode
@@ -46,16 +30,6 @@ def _encode_zone_name(name):
     return quote_plus(name).replace('%', '=')
 
 
-def _escape_unescaped_semicolons(value):
-    pieces = value.split(';')
-    if len(pieces) == 1:
-        return value
-    last = pieces.pop()
-    joined = ';'.join([p if p and p[-1] == '\\' else f'{p}\\' for p in pieces])
-    ret = f'{joined};{last}'
-    return ret
-
-
 class PowerDnsBaseProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC_SUBNETS = True
@@ -70,6 +44,7 @@ class PowerDnsBaseProvider(BaseProvider):
             'CAA',
             'CNAME',
             'DS',
+            'HTTPS',
             'LOC',
             'MX',
             'NAPTR',
@@ -77,18 +52,13 @@ class PowerDnsBaseProvider(BaseProvider):
             'PTR',
             'SSHFP',
             'SRV',
+            'SVCB',
             'TLSA',
             'TXT',
+            'URI',
             PowerDnsLuaRecord._type,
         )
     )
-    # These are only supported if we have a new enough octoDNS core
-    if SUPPORTS_SVCB:  # pragma: no cover
-        SUPPORTS.add('HTTPS')
-        SUPPORTS.add('SVCB')
-
-    if SUPPORTS_URI:  # pragma: no cover
-        SUPPORTS.add('URI')
 
     TIMEOUT = 5
 
@@ -187,221 +157,28 @@ class PowerDnsBaseProvider(BaseProvider):
     def _patch(self, path, data=None):
         return self._request('PATCH', path, data=data)
 
-    def _data_for_multiple(self, rrset):
-        # TODO: geo not supported
-        return {
-            'type': rrset['type'],
-            'values': [r['content'] for r in rrset['records']],
-            'ttl': rrset['ttl'],
-        }
-
-    _data_for_A = _data_for_multiple
-    _data_for_AAAA = _data_for_multiple
-    _data_for_NS = _data_for_multiple
-    _data_for_PTR = _data_for_multiple
-
-    def _data_for_TLSA(self, rrset):
-        values = []
-        for record in rrset['records']:
-            (
-                certificate_usage,
-                selector,
-                matching_type,
-                certificate_association_data,
-            ) = record['content'].split(' ', 3)
-            values.append(
-                {
-                    'certificate_usage': certificate_usage,
-                    'selector': selector,
-                    'matching_type': matching_type,
-                    'certificate_association_data': certificate_association_data,
-                }
-            )
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_DS(self, rrset):
-        values = []
-        for record in rrset['records']:
-            key_tag, algorithm, digest_type, digest = record['content'].split(
-                ' ', 3
-            )
-            value = {
-                'key_tag': key_tag,
-                'algorithm': algorithm,
-                'digest_type': digest_type,
-                'digest': digest,
-            }
-            values.append(value)
-
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_CAA(self, rrset):
-        values = []
-        for record in rrset['records']:
-            flags, tag, value = record['content'].split(' ', 2)
-            values.append({'flags': flags, 'tag': tag, 'value': value[1:-1]})
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_single(self, rrset):
-        return {
-            'type': rrset['type'],
-            'value': rrset['records'][0]['content'],
-            'ttl': rrset['ttl'],
-        }
-
-    _data_for_ALIAS = _data_for_single
-    _data_for_CNAME = _data_for_single
-
-    def _data_for_quoted(self, rrset):
-        return {
-            'type': rrset['type'],
-            'values': [
-                _escape_unescaped_semicolons(r['content'][1:-1])
-                for r in rrset['records']
-            ],
-            'ttl': rrset['ttl'],
-        }
-
-    _data_for_TXT = _data_for_quoted
-
-    def _data_for_LOC(self, rrset):
-        values = []
-        for record in rrset['records']:
-            (
-                lat_degrees,
-                lat_minutes,
-                lat_seconds,
-                lat_direction,
-                long_degrees,
-                long_minutes,
-                long_seconds,
-                long_direction,
-                altitude,
-                size,
-                precision_horz,
-                precision_vert,
-            ) = (record['content'].replace('m', '').split(' ', 11))
-            values.append(
-                {
-                    'lat_degrees': int(lat_degrees),
-                    'lat_minutes': int(lat_minutes),
-                    'lat_seconds': float(lat_seconds),
-                    'lat_direction': lat_direction,
-                    'long_degrees': int(long_degrees),
-                    'long_minutes': int(long_minutes),
-                    'long_seconds': float(long_seconds),
-                    'long_direction': long_direction,
-                    'altitude': float(altitude),
-                    'size': float(size),
-                    'precision_horz': float(precision_horz),
-                    'precision_vert': float(precision_vert),
-                }
-            )
-        return {'ttl': rrset['ttl'], 'type': rrset['type'], 'values': values}
-
-    def _data_for_MX(self, rrset):
-        values = []
-        for record in rrset['records']:
-            preference, exchange = record['content'].split(' ', 1)
-            values.append({'preference': preference, 'exchange': exchange})
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_NAPTR(self, rrset):
-        values = []
-        for record in rrset['records']:
-            order, preference, flags, service, regexp, replacement = record[
-                'content'
-            ].split(' ', 5)
-            values.append(
-                {
-                    'order': order,
-                    'preference': preference,
-                    'flags': flags[1:-1],
-                    'service': service[1:-1],
-                    'regexp': regexp[1:-1],
-                    'replacement': replacement,
-                }
-            )
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_SSHFP(self, rrset):
-        values = []
-        for record in rrset['records']:
-            algorithm, fingerprint_type, fingerprint = record['content'].split(
-                ' ', 2
-            )
-            values.append(
-                {
-                    'algorithm': algorithm,
-                    'fingerprint_type': fingerprint_type,
-                    'fingerprint': fingerprint,
-                }
-            )
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_SRV(self, rrset):
-        values = []
-        for record in rrset['records']:
-            priority, weight, port, target = record['content'].split(' ', 3)
-            values.append(
-                {
-                    'priority': priority,
-                    'weight': weight,
-                    'port': port,
-                    'target': target,
-                }
-            )
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_HTTPS(self, rrset):
-        values = []
-        for record in rrset['records']:
-            value = HttpsValue.parse_rdata_text(record['content'])
-            values.append(value)
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_SVCB(self, rrset):
-        values = []
-        for record in rrset['records']:
-            value = SvcbValue.parse_rdata_text(record['content'])
-            values.append(value)
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
-
-    def _data_for_LUA(self, rrset):
+    def _data_for_dynamic(self, rrset):
+        # A dynamic record always serializes to exactly one content entry in
+        # a PowerDNS "LUA" rrset; if that's what we have, and its qtype is
+        # dynamic-capable, try to decode the octodns-dynamic marker. Returns
+        # None when the rrset isn't a dynamic record in disguise, in which
+        # case it's a "real" PowerDnsProvider/LUA record.
         records = rrset['records']
-        # A dynamic record always serializes to exactly one content entry; if
-        # the rrset has one record matching a dynamic-capable qtype, try to
-        # decode the octodns-dynamic marker.
-        if len(records) == 1:
-            _type, script = records[0]['content'].split(' ', 1)
-            if (
-                _type in ('A', 'AAAA', 'CNAME')
-                and script.startswith('"')
-                and script.endswith('"')
-            ):
-                try:
-                    data = _dynamic_decode(script[1:-1], _type)
-                except ValueError:
-                    pass
-                else:
-                    data['ttl'] = rrset['ttl']
-                    return data
-        values = []
-        for record in records:
-            _type, script = record['content'].split(' ', 1)
-            values.append({'type': _type, 'script': script[1:-1]})
-        return {
-            'ttl': rrset['ttl'],
-            'type': PowerDnsLuaRecord._type,
-            'values': values,
-        }
-
-    def _data_for_URI(self, rrset):
-        values = []
-        for record in rrset['records']:
-            value = UriValue.parse_rdata_text(record['content'])
-            values.append(value)
-        return {'type': rrset['type'], 'values': values, 'ttl': rrset['ttl']}
+        if len(records) != 1:
+            return None
+        _type, script = records[0]['content'].split(' ', 1)
+        if not (
+            _type in ('A', 'AAAA', 'CNAME')
+            and script.startswith('"')
+            and script.endswith('"')
+        ):
+            return None
+        try:
+            data = _dynamic_decode(script[1:-1], _type)
+        except ValueError:
+            return None
+        data['ttl'] = rrset['ttl']
+        return data
 
     @property
     def powerdns_version(self):
@@ -561,23 +338,45 @@ class PowerDnsBaseProvider(BaseProvider):
 
         if resp:
             exists = True
-            for rrset in resp.json()['rrsets']:
-                _type = rrset['type']
-                _provider_specific_type = f'PowerDnsProvider/{_type}'
-                if (
-                    _type not in self.SUPPORTS
-                    and _provider_specific_type not in self.SUPPORTS
-                ):
+            rrsets = []
+            for pdns_rrset in resp.json()['rrsets']:
+                _type = pdns_rrset['type']
+                if _type == 'LUA':
+                    if PowerDnsLuaRecord._type not in self.SUPPORTS:
+                        continue
+                    # a "LUA" rrset may be an octoDNS dynamic record in
+                    # disguise; if so it's handled directly since it doesn't
+                    # have a 1:1 rrset/record type mapping like everything
+                    # else does
+                    data = self._data_for_dynamic(pdns_rrset)
+                    if data is not None:
+                        record_name = zone.hostname_from_fqdn(
+                            pdns_rrset['name']
+                        )
+                        record = Record.new(
+                            zone,
+                            record_name,
+                            data,
+                            source=self,
+                            lenient=lenient,
+                        )
+                        zone.add_record(record, lenient=lenient)
+                        continue
+                    _type = PowerDnsLuaRecord._type
+                elif _type not in self.SUPPORTS:
                     continue
-                data_for = getattr(self, f'_data_for_{_type}')
-                record_name = zone.hostname_from_fqdn(rrset['name'])
-                record = Record.new(
-                    zone,
-                    record_name,
-                    data_for(rrset),
-                    source=self,
-                    lenient=lenient,
+                rrsets.append(
+                    Rrset(
+                        pdns_rrset['name'],
+                        _type,
+                        pdns_rrset['ttl'],
+                        [r['content'] for r in pdns_rrset['records']],
+                    )
                 )
+
+            for record in Record.from_rrsets(
+                zone, rrsets, lenient=lenient, source=self
+            ):
                 zone.add_record(record, lenient=lenient)
 
         self.log.info(
@@ -587,138 +386,26 @@ class PowerDnsBaseProvider(BaseProvider):
         )
         return exists
 
-    def _records_for_multiple(self, record):
-        return [
-            {'content': v, 'disabled': False} for v in record.values
-        ], record._type
-
-    def _records_for_dynamic(self, record):
-        script = _dynamic_encode(record)
-        content = f'{record._type} "{script}"'
-        return [{'content': content, 'disabled': False}], 'LUA'
-
-    def _records_for_A(self, record):
-        if record.dynamic:
-            return self._records_for_dynamic(record)
-        return self._records_for_multiple(record)
-
-    _records_for_AAAA = _records_for_A
-    _records_for_NS = _records_for_multiple
-    _records_for_PTR = _records_for_multiple
-
-    def _records_for_TLSA(self, record):
-        return [
-            {
-                'content': f'{v.certificate_usage} {v.selector} {v.matching_type} {v.certificate_association_data}',
-                'disabled': False,
-            }
-            for v in record.values
-        ], record._type
-
-    def _records_for_DS(self, record):
-        data = []
-        for v in record.values:
-            content = f'{v.key_tag} {v.algorithm} {v.digest_type} {v.digest}'
-            data.append({'content': content, 'disabled': False})
-        return data, record._type
-
-    def _records_for_CAA(self, record):
-        return [
-            {'content': f'{v.flags} {v.tag} "{v.value}"', 'disabled': False}
-            for v in record.values
-        ], record._type
-
-    def _records_for_single(self, record):
-        return [{'content': record.value, 'disabled': False}], record._type
-
-    _records_for_ALIAS = _records_for_single
-
-    def _records_for_CNAME(self, record):
-        if record.dynamic:
-            return self._records_for_dynamic(record)
-        return self._records_for_single(record)
-
-    def _records_for_quoted(self, record):
-        return [
-            {'content': f'"{v}"', 'disabled': False} for v in record.values
-        ], record._type
-
-    _records_for_TXT = _records_for_quoted
-
-    def _records_for_LOC(self, record):
-        return [
-            {
-                'content': '%d %d %0.3f %s %d %d %.3f %s %0.2fm %0.2fm %0.2fm %0.2fm'
-                % (
-                    int(v.lat_degrees),
-                    int(v.lat_minutes),
-                    float(v.lat_seconds),
-                    v.lat_direction,
-                    int(v.long_degrees),
-                    int(v.long_minutes),
-                    float(v.long_seconds),
-                    v.long_direction,
-                    float(v.altitude),
-                    float(v.size),
-                    float(v.precision_horz),
-                    float(v.precision_vert),
-                ),
-                'disabled': False,
-            }
-            for v in record.values
-        ], record._type
-
-    def _records_for_MX(self, record):
-        return [
-            {'content': f'{v.preference} {v.exchange}', 'disabled': False}
-            for v in record.values
-        ], record._type
-
-    def _records_for_NAPTR(self, record):
-        return [
-            {
-                'content': f'{v.order} {v.preference} "{v.flags}" "{v.service}" '
-                f'"{v.regexp}" {v.replacement}',
-                'disabled': False,
-            }
-            for v in record.values
-        ], record._type
-
-    def _records_for_SSHFP(self, record):
-        return [
-            {
-                'content': f'{v.algorithm} {v.fingerprint_type} {v.fingerprint}',
-                'disabled': False,
-            }
-            for v in record.values
-        ], record._type
-
-    def _records_for_SRV(self, record):
-        return [
-            {
-                'content': f'{v.priority} {v.weight} {v.port} {v.target}',
-                'disabled': False,
-            }
-            for v in record.values
-        ], record._type
-
-    def _records_for_SVCB(self, record):
-        return [
-            {'content': v.rdata_text, 'disabled': False} for v in record.values
-        ], record._type
-
-    _records_for_HTTPS = _records_for_SVCB
-    _records_for_URI = _records_for_SVCB
-
-    def _records_for_PowerDnsProvider_LUA(self, record):
-        return [
-            {'content': f'{v._type} "{v.script}"', 'disabled': False}
-            for v in record.values
-        ], 'LUA'
+    def _rrset_for(self, record):
+        if getattr(record, 'dynamic', None):
+            # dynamic A/AAAA/CNAME records are always stored as a single
+            # "LUA" rrset carrying the octodns-dynamic marker; they don't
+            # have a 1:1 rrset/record type mapping like everything else does
+            script = _dynamic_encode(record)
+            content = f'{record._type} "{script}"'
+            return Rrset(record.fqdn, 'LUA', record.ttl, [content])
+        rrset = record.to_rrset()
+        if rrset._type == PowerDnsLuaRecord._type:
+            # octoDNS type name -> PowerDNS rrset type
+            return Rrset(rrset.name, 'LUA', rrset.ttl, rrset.rdatas)
+        return rrset
 
     def _records_for(self, record):
-        name = f'_records_for_{record._type}'.replace('/', '_')
-        return getattr(self, name)(record)
+        rrset = self._rrset_for(record)
+        records = [
+            {'content': rdata, 'disabled': False} for rdata in rrset.rdatas
+        ]
+        return records, rrset._type
 
     def _mod_Create(self, change):
         new = change.new

--- a/octodns_powerdns/record.py
+++ b/octodns_powerdns/record.py
@@ -1,5 +1,5 @@
 from octodns.equality import EqualityTupleMixin
-from octodns.record import Record, ValuesMixin
+from octodns.record import RdataParseError, Record, ValuesMixin
 
 try:  # pragma: no cover
     import octodns.record.validator
@@ -11,6 +11,13 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     _HAS_VALUE_VALIDATOR = False
     _HAS_VALIDATION_REASON = False
+
+
+def _unquote(value):
+    # PowerDNS always wraps the LUA script in double quotes; strip them off,
+    # mirroring octoDNS core's own `unquote()` helper
+    # (octodns.record.base.unquote, not part of the public API surface).
+    return value[1:-1]
 
 
 def _validate_powerdns_lua_values(data):
@@ -57,6 +64,17 @@ class _PowerDnsLuaValue(EqualityTupleMixin, dict):
     @classmethod
     def process(cls, values):
         return [_PowerDnsLuaValue(v) for v in values]
+
+    @classmethod
+    def from_rdata_text(cls, rdata):
+        try:
+            _type, script = rdata.split(' ', 1)
+        except ValueError:
+            raise RdataParseError()
+        return {'type': _type, 'script': _unquote(script)}
+
+    def to_rdata_text(self):
+        return f'{self._type} "{self.script}"'
 
     def __init__(self, value):
         self._type = value['type']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "octodns>=1.5.0",
+    "octodns>=1.22.0",
     "requests>=2.26.0",
 ]
 
@@ -84,7 +84,6 @@ sections = "FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
   'error',
-  'ignore:.*DEPRECATED.*2.0',
   # required until migrate the check and require octoDNS >= 2.x
   'ignore:`_PowerDnsLuaValue.validate` classmethod is DEPRECATED:DeprecationWarning:octodns.record.base',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,11 @@ msgpack==1.2.1
 mypy-extensions==1.1.0
 natsort==8.4.0
 nh3==0.3.5
-octodns==1.19.0
+# TODO: TEMPORARY - octodns 1.22.0 (with the new RDATA API from core PR #1452)
+# is unreleased. Pinning to the PR branch so CI can exercise this migration;
+# revert to a released `octodns==1.22.0` (regenerated via
+# ./script/update-requirements) once it ships.
+octodns @ git+https://github.com/octodns/octodns.git@refs/pull/1452/head
 packaging==26.2
 pathspec==1.1.1
 platformdirs==4.10.0

--- a/script/coverage
+++ b/script/coverage
@@ -10,7 +10,7 @@ SOURCE_DIR="octodns_powerdns/"
 # Don't allow disabling coverage
 PRAGMA_OUTPUT=$(grep -r -I --line-number "# pragma: \+no.*cover" "$SOURCE_DIR" || echo)
 PRAGMA_COUNT=$(echo "$PRAGMA_OUTPUT" | grep -c . || true)
-PRAGMA_ALLOWED=11
+PRAGMA_ALLOWED=5
 if [ "$PRAGMA_COUNT" -gt "$PRAGMA_ALLOWED" ]; then
   echo "Found $PRAGMA_COUNT instances of 'pragma: no cover' (no more than $PRAGMA_ALLOWED allowed):"
   echo "$PRAGMA_OUTPUT"

--- a/tests/test_octodns_provider_powerdns.py
+++ b/tests/test_octodns_provider_powerdns.py
@@ -20,7 +20,6 @@ from octodns_powerdns import (
     PowerDnsBaseProvider,
     PowerDnsProvider,
     _encode_zone_name,
-    _escape_unescaped_semicolons,
 )
 from octodns_powerdns.record import PowerDnsLuaRecord, _PowerDnsLuaValue
 
@@ -589,50 +588,59 @@ class TestPowerDnsProvider(TestCase):
                 )
             )
 
-    def test_unescaped_semicolon(self):
-        # no escapes
-        self.assertEqual('', _escape_unescaped_semicolons(''))
-        self.assertEqual('hello', _escape_unescaped_semicolons('hello'))
-        self.assertEqual(
-            'hello world!', _escape_unescaped_semicolons('hello world!')
+    def test_txt_round_trip(self):
+        # TXT semicolon escaping and 255-octet chunking are now delegated to
+        # octoDNS core's RDATA API; exercise them through a real populate()
+        # rather than a standalone helper.
+        provider = PowerDnsProvider(
+            'test', 'non.existent', 'api-key', strict_supports=False
         )
 
-        # good
-        self.assertEqual('\\;', _escape_unescaped_semicolons('\\;'))
-        self.assertEqual('foo\\;', _escape_unescaped_semicolons('foo\\;'))
-        self.assertEqual(
-            'foo\\; bar\\;', _escape_unescaped_semicolons('foo\\; bar\\;')
-        )
-        self.assertEqual(
-            'foo\\; bar\\; baz\\;',
-            _escape_unescaped_semicolons('foo\\; bar\\; baz\\;'),
-        )
+        long_value = 'x' * 400
+        rrsets = {
+            'rrsets': [
+                {
+                    'name': 'txt.unit.tests.',
+                    'type': 'TXT',
+                    'ttl': 600,
+                    'records': [
+                        {
+                            'content': '"v=DKIM1\\;k=rsa;s=email\\;h=sha256"',
+                            'disabled': False,
+                        }
+                    ],
+                },
+                {
+                    'name': 'long.unit.tests.',
+                    'type': 'TXT',
+                    'ttl': 600,
+                    'records': [
+                        {
+                            'content': f'"{long_value[:255]}" "{long_value[255:]}"',
+                            'disabled': False,
+                        }
+                    ],
+                },
+            ]
+        }
 
-        # missing
-        self.assertEqual('\\;', _escape_unescaped_semicolons(';'))
-        self.assertEqual('foo\\;', _escape_unescaped_semicolons('foo;'))
-        self.assertEqual(
-            'foo\\; bar\\;', _escape_unescaped_semicolons('foo; bar;')
-        )
-        self.assertEqual(
-            'foo\\; bar\\; baz\\;',
-            _escape_unescaped_semicolons('foo; bar; baz;'),
-        )
+        with requests_mock() as mock:
+            mock.get(ANY, status_code=200, json=rrsets)
+            zone = Zone('unit.tests.', [])
+            provider.populate(zone)
 
-        # partial
+        by_name = {r.name: r for r in zone.records}
         self.assertEqual(
-            'foo\\; bar\\; baz\\;',
-            _escape_unescaped_semicolons('foo; bar\\; baz;'),
+            ['v=DKIM1\\;k=rsa\\;s=email\\;h=sha256'], by_name['txt'].values
         )
+        self.assertEqual([long_value], by_name['long'].values)
 
-        # double escaped, left alone
-        self.assertEqual('foo\\\\;', _escape_unescaped_semicolons('foo\\\\;'))
-
-        # double ;;
-        self.assertEqual('foo\\;\\;', _escape_unescaped_semicolons('foo\\;\\;'))
-        self.assertEqual('foo\\;\\;', _escape_unescaped_semicolons('foo;\\;'))
-        self.assertEqual('foo\\;\\;', _escape_unescaped_semicolons('foo\\;;'))
-        self.assertEqual('foo\\;\\;', _escape_unescaped_semicolons('foo;;'))
+        # and writing it back out re-chunks at 255 octets
+        records, _type = provider._records_for(by_name['long'])
+        self.assertEqual('TXT', _type)
+        self.assertEqual(
+            f'"{long_value[:255]}" "{long_value[255:]}"', records[0]['content']
+        )
 
     def test_list_zones(self):
         with requests_mock() as mock:
@@ -649,55 +657,43 @@ class TestPowerDnsProvider(TestCase):
             )
             self.assertEqual(['alpha.com.', 'zeta.net.'], provider.list_zones())
 
-    def test_data_for_DS_compat(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+    def test_ds_round_trip(self):
+        # DS conversion is now handled entirely by octoDNS core's RDATA API;
+        # exercise read and write through the provider's public surface.
+        provider = PowerDnsProvider(
+            'test', 'non.existent', 'api-key', strict_supports=False
+        )
 
-        rrset = {
-            'records': [{'content': 'one two three four'}],
-            'ttl': 42,
-            'type': 'DS',
+        content = (
+            '2371 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+            '0123456789ABCDEF'
+        )
+        rrsets = {
+            'rrsets': [
+                {
+                    'name': 'ds.unit.tests.',
+                    'type': 'DS',
+                    'ttl': 3600,
+                    'records': [{'content': content, 'disabled': False}],
+                }
+            ]
         }
 
-        # new
-        value = provider._data_for_DS(rrset)['values'][0]
-        self.assertEqual(
-            {
-                'algorithm': 'two',
-                'digest': 'four',
-                'digest_type': 'three',
-                'key_tag': 'one',
-            },
-            value,
-        )
+        with requests_mock() as mock:
+            mock.get(ANY, status_code=200, json=rrsets)
+            zone = Zone('unit.tests.', [])
+            provider.populate(zone)
 
-    def test_records_for_DS_compat(self):
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
+        record = next(iter(zone.records))
+        value = record.values[0]
+        self.assertEqual(2371, value.key_tag)
+        self.assertEqual(13, value.algorithm)
+        self.assertEqual(2, value.digest_type)
+        self.assertEqual(content.lower().split(' ', 3)[3], value.digest)
 
-        class DummyRecord:
-            _type = 'DS'
-
-            def __init__(self, value):
-                self.values = [value]
-
-        class NewFields:
-            key_tag = 'key_tag'
-            algorithm = 'algorithm'
-            digest_type = 'digest_type'
-            digest = 'digest'
-
-        new_fields = NewFields()
-
-        # new
-        data = provider._records_for_DS(DummyRecord(new_fields))[0]
-        self.assertEqual(
-            [
-                {
-                    'content': 'key_tag algorithm digest_type digest',
-                    'disabled': False,
-                }
-            ],
-            data,
-        )
+        records, _type = provider._records_for(record)
+        self.assertEqual('DS', _type)
+        self.assertEqual(content.lower(), records[0]['content'])
 
     def _dynamic_a(self, name='www', default='5.5.5.5'):
         zone = Zone('unit.tests.', [])
@@ -724,7 +720,7 @@ class TestPowerDnsProvider(TestCase):
     def test_records_for_dynamic_A(self):
         provider = PowerDnsProvider('test', 'non.existent', 'api-key')
         record = self._dynamic_a()
-        records, _type = provider._records_for_A(record)
+        records, _type = provider._records_for(record)
         self.assertEqual('LUA', _type)
         self.assertEqual(1, len(records))
         self.assertTrue(records[0]['content'].startswith('A "'))
@@ -754,7 +750,7 @@ class TestPowerDnsProvider(TestCase):
                 },
             },
         )
-        records, _type = provider._records_for_CNAME(record)
+        records, _type = provider._records_for(record)
         self.assertEqual('LUA', _type)
         self.assertTrue(records[0]['content'].startswith('CNAME "'))
 
@@ -766,55 +762,61 @@ class TestPowerDnsProvider(TestCase):
             'alias',
             {'type': 'CNAME', 'ttl': 60, 'value': 'target.example.com.'},
         )
-        records, _type = provider._records_for_CNAME(record)
+        records, _type = provider._records_for(record)
         self.assertEqual('CNAME', _type)
         self.assertEqual('target.example.com.', records[0]['content'])
 
-    def test_data_for_LUA_dynamic_marker(self):
+    def test_data_for_dynamic_marker(self):
         provider = PowerDnsProvider('test', 'non.existent', 'api-key')
         record = self._dynamic_a()
-        records, _ = provider._records_for_A(record)
+        records, _ = provider._records_for(record)
         rrset = {
             'name': 'www.unit.tests.',
             'type': 'LUA',
             'ttl': 60,
             'records': records,
         }
-        data = provider._data_for_LUA(rrset)
+        data = provider._data_for_dynamic(rrset)
         self.assertEqual('A', data['type'])
         self.assertEqual(60, data['ttl'])
         self.assertIn('dynamic', data)
         self.assertEqual(['5.5.5.5'], data['values'])
 
-    def test_data_for_LUA_single_no_marker_falls_back(self):
+    def _populate_lua(self, records):
+        provider = PowerDnsProvider(
+            'test', 'non.existent', 'api-key', strict_supports=False
+        )
+        rrsets = {
+            'rrsets': [
+                {
+                    'name': 'lua.unit.tests.',
+                    'type': 'LUA',
+                    'ttl': 60,
+                    'records': records,
+                }
+            ]
+        }
+        with requests_mock() as mock:
+            mock.get(ANY, status_code=200, json=rrsets)
+            zone = Zone('unit.tests.', [])
+            provider.populate(zone)
+        return next(iter(zone.records))
+
+    def test_populate_lua_single_no_marker_falls_back(self):
         # Single-record LUA with a qtype we support but no octodns marker —
         # should fall through to the PowerDnsLuaRecord path.
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
-        rrset = {
-            'name': 'lua.unit.tests.',
-            'type': 'LUA',
-            'ttl': 60,
-            'records': [
-                {'content': 'A ";return \'1.2.3.4\'"', 'disabled': False}
-            ],
-        }
-        data = provider._data_for_LUA(rrset)
-        self.assertEqual(PowerDnsLuaRecord._type, data['type'])
+        record = self._populate_lua(
+            [{'content': 'A ";return \'1.2.3.4\'"', 'disabled': False}]
+        )
+        self.assertEqual(PowerDnsLuaRecord._type, record._type)
 
-    def test_data_for_LUA_single_unsupported_qtype_falls_back(self):
+    def test_populate_lua_single_unsupported_qtype_falls_back(self):
         # Single-record LUA for a qtype we don't translate dynamically —
         # should also fall through.
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
-        rrset = {
-            'name': 'lua.unit.tests.',
-            'type': 'LUA',
-            'ttl': 60,
-            'records': [
-                {'content': 'TXT "return \'hello\'"', 'disabled': False}
-            ],
-        }
-        data = provider._data_for_LUA(rrset)
-        self.assertEqual(PowerDnsLuaRecord._type, data['type'])
+        record = self._populate_lua(
+            [{'content': 'TXT "return \'hello\'"', 'disabled': False}]
+        )
+        self.assertEqual(PowerDnsLuaRecord._type, record._type)
 
     def test_mod_Update_same_rrset_type(self):
         provider = PowerDnsProvider('test', 'non.existent', 'api-key')
@@ -970,43 +972,38 @@ class TestPowerDnsProvider(TestCase):
 
     def test_dynamic_round_trip_via_rrset(self):
         # End-to-end codegen + parse: build a dynamic A, run it through
-        # _records_for_A to produce the rrset content, then hand that rrset
-        # back to _data_for_LUA and rebuild a record. The rebuilt record's
-        # serialized form must match the original — that's the invariant
-        # populate-after-apply relies on.
+        # _records_for to produce the rrset content, then hand that rrset
+        # back to _data_for_dynamic and rebuild a record. The rebuilt
+        # record's serialized form must match the original — that's the
+        # invariant populate-after-apply relies on.
         provider = PowerDnsProvider('test', 'non.existent', 'api-key')
         original = self._dynamic_a()
-        records, _type = provider._records_for_A(original)
+        records, _type = provider._records_for(original)
         rrset = {
             'name': original.fqdn,
             'type': _type,
             'ttl': original.ttl,
             'records': records,
         }
-        data = provider._data_for_LUA(rrset)
+        data = provider._data_for_dynamic(rrset)
         rebuilt = Record.new(Zone('unit.tests.', []), original.name, data)
         self.assertEqual(original._data(), rebuilt._data())
 
-    def test_data_for_LUA_multi_record_legacy_path(self):
+    def test_populate_lua_multi_record_legacy_path(self):
         # Multi-record LUA rrsets (the pre-dynamic PowerDnsLuaRecord use case)
         # are never decoded as dynamic, even if one of the entries happens to
         # look like a marker — the dynamic decoder only runs for single-entry
         # rrsets.
-        provider = PowerDnsProvider('test', 'non.existent', 'api-key')
-        rrset = {
-            'name': 'lua.unit.tests.',
-            'type': 'LUA',
-            'ttl': 60,
-            'records': [
+        record = self._populate_lua(
+            [
                 {'content': 'A ";return \'1.2.3.4\'"', 'disabled': False},
                 {'content': 'AAAA ";return \'fc00::42\'"', 'disabled': False},
-            ],
-        }
-        data = provider._data_for_LUA(rrset)
-        self.assertEqual(PowerDnsLuaRecord._type, data['type'])
-        self.assertEqual(2, len(data['values']))
+            ]
+        )
+        self.assertEqual(PowerDnsLuaRecord._type, record._type)
+        self.assertEqual(2, len(record.values))
 
-    def test_data_for_LUA_malformed_marker_raises(self):
+    def test_data_for_dynamic_malformed_marker_raises(self):
         # A content entry that starts with the dynamic marker but carries a
         # broken payload must raise ProviderException, not silently fall back
         # to PowerDnsLuaRecord — a corrupt marker is a bug, not a missing one.
@@ -1021,10 +1018,72 @@ class TestPowerDnsProvider(TestCase):
             'records': [{'content': broken, 'disabled': False}],
         }
         with self.assertRaises(ProviderException):
-            provider._data_for_LUA(rrset)
+            provider._data_for_dynamic(rrset)
+
+    def test_populate_lua_malformed_marker_raises(self):
+        # The same malformed marker surfaces through populate() as well,
+        # since that's the path a real PATCH response goes through.
+        from octodns_powerdns.dynamic import DYNAMIC_MARKER
+
+        broken = f'A ";{DYNAMIC_MARKER}AAAA"'
+        with self.assertRaises(ProviderException):
+            self._populate_lua([{'content': broken, 'disabled': False}])
+
+    def test_populate_lua_excluded_from_supports(self):
+        # When the provider-specific LUA type isn't in SUPPORTS, "LUA"
+        # rrsets are skipped entirely -- including ones that are actually a
+        # dynamic record in disguise.
+        class NoLuaProvider(PowerDnsProvider):
+            SUPPORTS = PowerDnsProvider.SUPPORTS - {PowerDnsLuaRecord._type}
+
+        provider = NoLuaProvider(
+            'test', 'non.existent', 'api-key', strict_supports=False
+        )
+        rrsets = {
+            'rrsets': [
+                {
+                    'name': 'lua.unit.tests.',
+                    'type': 'LUA',
+                    'ttl': 60,
+                    'records': [
+                        {
+                            'content': 'A ";return \'1.2.3.4\'"',
+                            'disabled': False,
+                        }
+                    ],
+                }
+            ]
+        }
+        with requests_mock() as mock:
+            mock.get(ANY, status_code=200, json=rrsets)
+            zone = Zone('unit.tests.', [])
+            provider.populate(zone)
+        self.assertEqual(set(), zone.records)
 
 
 class TestPowerDnsLuaRecord(TestCase):
+    def test_rdata_text(self):
+        from octodns.record import RdataParseError
+
+        self.assertEqual(
+            {'type': 'A', 'script': "'1.2.3.4'"},
+            _PowerDnsLuaValue.from_rdata_text('A "\'1.2.3.4\'"'),
+        )
+
+        value = _PowerDnsLuaValue({'type': 'A', 'script': "'1.2.3.4'"})
+        self.assertEqual('A "\'1.2.3.4\'"', value.to_rdata_text())
+
+        # round trip
+        self.assertEqual(
+            value,
+            _PowerDnsLuaValue(
+                _PowerDnsLuaValue.from_rdata_text(value.to_rdata_text())
+            ),
+        )
+
+        with self.assertRaises(RdataParseError):
+            _PowerDnsLuaValue.from_rdata_text('no-space-here')
+
     def test_basics(self):
         zone = Zone('unit.tests.', [])
 


### PR DESCRIPTION
## Summary

octoDNS core PR [octodns/octodns#1452](https://github.com/octodns/octodns/pull/1452) (unreleased, ships as `octodns` 1.22.0) adds a spec-compliant RDATA conversion API for provider modules: a grouped `Rrset(name, _type, ttl, rdatas)` carrier, `Record.from_rrset()`/`Record.from_rrsets()`, `record.to_rrset()`, and per-value `from_rdata_text()`/`to_rdata_text()`. This PR migrates octodns-powerdns onto it, mirroring the octodns-bind migration in [octodns/octodns-bind#112](https://github.com/octodns/octodns-bind/pull/112) and using this provider as a second real-world exercise of the new API.

- Replaces ~30 hand-rolled `_data_for_*`/`_records_for_*` methods (bounded `split()`, blind `[1:-1]` quote-stripping, a bespoke TXT semicolon escaper) with `Record.from_rrsets()` on read and `record.to_rrset()` on write. PowerDNS's rrset `content` field is already RDATA presentation text, so this collapses almost entirely onto the new core API.
- Gives `_PowerDnsLuaValue` (the `PowerDnsProvider/LUA` type) `from_rdata_text()`/`to_rdata_text()` so it flows through the same generic path as every other type; only dynamic A/AAAA/CNAME-as-LUA encoding still needs a dedicated helper, since it has no 1:1 rrset/record type mapping.
- Drops the `SUPPORTS_SVCB`/`SUPPORTS_URI` import-based feature detection now that `octodns>=1.22.0` guarantees those value types exist.
- Existing fixtures round-trip byte-identically (TXT semicolon escaping, DS/TLSA hex case, LOC decimal formatting), while fixing a latent bug where TXT content over 255 octets was written as a single oversized character-string instead of being chunked.
- `requirements.txt` temporarily pins `octodns` to the core PR branch so CI can exercise this before it's released; revert to a released `octodns==1.22.0` once it ships (see TODO comment in the file).

## Test plan

- [x] `./script/bootstrap`
- [x] `./script/test` — 66 tests passing
- [x] `./script/coverage` — 100% coverage (lowered `PRAGMA_ALLOWED` from 11 to 5 since removing the `SUPPORTS_SVCB`/`SUPPORTS_URI` guards drops 6 `# pragma: no cover` lines)
- [x] `./script/cibuild` — lint, format, coverage all green
- [x] Removed the blanket `ignore:.*DEPRECATED.*2.0` pytest filter (added in a prior commit specifically to mask the deprecations this PR eliminates) — suite passes clean with `filterwarnings = ['error', ...]`
- [ ] `./script/cibuild-package` fails only because `octodns>=1.22.0` isn't on PyPI yet (same limitation the temporary git pin exists for); will pass once octodns 1.22.0 ships